### PR TITLE
Implement Fractal Frontier idle interface

### DIFF
--- a/src/app/pages/fractalviewer.tsx
+++ b/src/app/pages/fractalviewer.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from "react";
+import type { ReactElement } from "react";
+
+type ComplexParameter = {
+  real: number;
+  imaginary: number;
+};
+
+type FractalViewerProps = {
+  depth: number;
+  parameter: ComplexParameter;
+  amplifiers: number;
+};
+
+const CANVAS_WIDTH = 360;
+const CANVAS_HEIGHT = 260;
+
+const clamp = (value: number, lower: number, upper: number): number =>
+  Math.max(lower, Math.min(value, upper));
+
+const renderFractal = (
+  context: CanvasRenderingContext2D,
+  depth: number,
+  parameter: ComplexParameter,
+  amplifiers: number,
+) => {
+  const width = context.canvas.width;
+  const height = context.canvas.height;
+  const maxIterations = Math.floor(40 + depth * 14 + amplifiers * 12);
+  const zoom = Math.pow(1.3, depth + amplifiers * 0.5);
+  const paletteShift = (depth * 17 + amplifiers * 45) % 360;
+
+  const imageData = context.createImageData(width, height);
+  const data = imageData.data;
+
+  let dataIndex = 0;
+
+  for (let py = 0; py < height; py += 1) {
+    const imaginaryComponent =
+      (py - height / 2) / (0.5 * zoom * height) + parameter.imaginary;
+
+    for (let px = 0; px < width; px += 1) {
+      const realComponent =
+        (px - width / 2) / (0.5 * zoom * width) + parameter.real;
+
+      let x = 0;
+      let y = 0;
+      let iteration = 0;
+
+      while (x * x + y * y <= 4 && iteration < maxIterations) {
+        const xTemp = x * x - y * y + realComponent;
+        y = 2 * x * y + imaginaryComponent;
+        x = xTemp;
+        iteration += 1;
+      }
+
+      const normalised = iteration / maxIterations;
+      const hue = (paletteShift + 360 * Math.pow(normalised, 0.6)) % 360;
+      const saturation = 70 + Math.sin(depth * 0.4) * 10;
+      const lightness = iteration === maxIterations ? 5 : clamp(40 + normalised * 50, 10, 95);
+
+      const [r, g, b] = hslToRgb(hue / 360, saturation / 100, lightness / 100);
+
+      data[dataIndex + 0] = r;
+      data[dataIndex + 1] = g;
+      data[dataIndex + 2] = b;
+      data[dataIndex + 3] = 255;
+      dataIndex += 4;
+    }
+  }
+
+  context.putImageData(imageData, 0, 0);
+};
+
+const hslToRgb = (h: number, s: number, l: number): [number, number, number] => {
+  if (s === 0) {
+    const value = Math.round(l * 255);
+    return [value, value, value];
+  }
+
+  const hueToRgb = (p: number, q: number, t: number): number => {
+    let temp = t;
+    if (temp < 0) {
+      temp += 1;
+    }
+    if (temp > 1) {
+      temp -= 1;
+    }
+    if (temp < 1 / 6) {
+      return p + (q - p) * 6 * temp;
+    }
+    if (temp < 1 / 2) {
+      return q;
+    }
+    if (temp < 2 / 3) {
+      return p + (q - p) * (2 / 3 - temp) * 6;
+    }
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  const r = hueToRgb(p, q, h + 1 / 3);
+  const g = hueToRgb(p, q, h);
+  const b = hueToRgb(p, q, h - 1 / 3);
+
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+};
+
+export default function FractalViewer({
+  depth,
+  parameter,
+  amplifiers,
+}: FractalViewerProps): ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return;
+    }
+    renderFractal(context, depth, parameter, amplifiers);
+  }, [depth, parameter, amplifiers]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_WIDTH}
+      height={CANVAS_HEIGHT}
+      className="fractal-canvas"
+      aria-label="Fractal renderer showing the current zoom level"
+    />
+  );
+}
+

--- a/src/app/pages/starthere.tsx
+++ b/src/app/pages/starthere.tsx
@@ -1,17 +1,490 @@
-import type {ReactElement} from "react";
+'use client';
+
+import "@/styles/starthere.css";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactElement } from "react";
+
+import { Box, Button, Card, Flex, Grid, Heading, Separator, Slider, Text } from "@radix-ui/themes";
+
+import FractalViewer from "./fractalviewer";
 import StartHereMenu from "./startheremenu";
-import { Box } from "@radix-ui/themes";
 
+type UpgradeKey = "probe" | "processor" | "stabilizer";
 
-export default function StartHere():ReactElement {
-    return(
-        <Box
-            className="startherebox"
-        >
-            <StartHereMenu />
-            <div>
-                Test
-            </div>
-        </Box>
+type ComplexParameter = {
+  real: number;
+  imaginary: number;
+};
+
+type UpgradeConfig = {
+  title: string;
+  description: string;
+  baseCost: number;
+  growth: number;
+  flavor: string;
+};
+
+const UPGRADE_CONFIG: Record<UpgradeKey, UpgradeConfig> = {
+  probe: {
+    title: "Fractal Probes",
+    description: "Deploy autonomous explorers that map detail while you plan the next zoom.",
+    baseCost: 35,
+    growth: 1.45,
+    flavor: "Their quantum lenses never blink.",
+  },
+  processor: {
+    title: "Quantum Processors",
+    description: "Accelerate every calculation, multiplying the insight gathered by your probes.",
+    baseCost: 120,
+    growth: 1.6,
+    flavor: "The algorithms hum in complex harmony.",
+  },
+  stabilizer: {
+    title: "Dimensional Stabilizers",
+    description: "Anchor deeper zoom levels so the structure holds while automation continues.",
+    baseCost: 220,
+    growth: 1.55,
+    flavor: "Reality threads itself tighter around the frontier.",
+  },
+};
+
+const FRACTAL_ZONES = [
+  {
+    name: "Mandelbrot Core",
+    requirement: 0,
+    bonus: 0.0,
+    description: "The familiar heart of the set, steady and welcoming.",
+  },
+  {
+    name: "Seahorse Valley",
+    requirement: 4,
+    bonus: 0.08,
+    description: "Filigree spirals curl like cosmic seahorses, enriching every data packet.",
+  },
+  {
+    name: "Spiral Nebula",
+    requirement: 7,
+    bonus: 0.18,
+    description: "Twin galaxies of recursion feed each other, boosting production dramatically.",
+  },
+  {
+    name: "Mini-Brot Frontier",
+    requirement: 11,
+    bonus: 0.3,
+    description: "Self-similarity upon self-similarity. You glimpse new universes in each pixel.",
+  },
+  {
+    name: "Hyperbolic Bloom",
+    requirement: 15,
+    bonus: 0.45,
+    description: "Geometries bloom beyond Euclid. Ascension-grade knowledge saturates every line.",
+  },
+];
+
+const DIMENSIONAL_TARGET: ComplexParameter = { real: -0.75, imaginary: 0.11 };
+
+const formatNumber = (value: number): string => {
+  if (value >= 1e9) {
+    return `${(value / 1e9).toFixed(2)}B`;
+  }
+  if (value >= 1e6) {
+    return `${(value / 1e6).toFixed(2)}M`;
+  }
+  if (value >= 1e3) {
+    return `${(value / 1e3).toFixed(2)}K`;
+  }
+  return value.toFixed(0);
+};
+
+export default function StartHere(): ReactElement {
+  const [fractalData, setFractalData] = useState<number>(42);
+  const [depth, setDepth] = useState<number>(0);
+  const [upgrades, setUpgrades] = useState<Record<UpgradeKey, number>>({
+    probe: 0,
+    processor: 0,
+    stabilizer: 0,
+  });
+  const [dimensionalPoints, setDimensionalPoints] = useState<number>(0);
+  const [ascensionLevel, setAscensionLevel] = useState<number>(0);
+  const [amplifiers, setAmplifiers] = useState<number>(0);
+  const [complexParameter, setComplexParameter] = useState<ComplexParameter>({
+    ...DIMENSIONAL_TARGET,
+  });
+  const [activityLog, setActivityLog] = useState<string[]>([
+    "Begin exploration: calibrating renderers…",
+  ]);
+  const [lastZone, setLastZone] = useState<string>(FRACTAL_ZONES[0]?.name ?? "");
+
+  const pushLog = useCallback((message: string) => {
+    setActivityLog((previous) => [message, ...previous].slice(0, 6));
+  }, []);
+
+  const upgradeCost = useCallback(
+    (key: UpgradeKey) => {
+      const config = UPGRADE_CONFIG[key];
+      const owned = upgrades[key];
+      return Math.floor(config.baseCost * Math.pow(config.growth, owned));
+    },
+    [upgrades],
+  );
+
+  const nextDepthLevel = Math.floor(depth) + 1;
+  const zoomCost = useMemo(
+    () => Math.floor(18 * Math.pow(1.55, nextDepthLevel)),
+    [nextDepthLevel],
+  );
+
+  const productionMultiplier = useMemo(() => {
+    const ascensionBonus = 1 + ascensionLevel * 0.25 + amplifiers * 0.35;
+    const depthBonus = 1 + Math.floor(depth) * 0.05;
+    const dimensionalBonus = 1 + dimensionalPoints * 0.02;
+    return ascensionBonus * depthBonus * dimensionalBonus;
+  }, [ascensionLevel, amplifiers, depth, dimensionalPoints]);
+
+  const parameterEfficiency = useMemo(() => {
+    const distance = Math.hypot(
+      complexParameter.real - DIMENSIONAL_TARGET.real,
+      complexParameter.imaginary - DIMENSIONAL_TARGET.imaginary,
     );
+    return Math.max(0.65, 1.45 - distance * 1.1);
+  }, [complexParameter]);
+
+  const baseProduction = useMemo(() => {
+    const probeYield = upgrades.probe * 0.9;
+    const processorYield = upgrades.processor * 3.5;
+    const stabilizerYield = upgrades.stabilizer * 1.6;
+    return probeYield + processorYield + stabilizerYield;
+  }, [upgrades]);
+
+  const dataPerSecond = useMemo(() => {
+    if (baseProduction <= 0) {
+      return 0;
+    }
+    return baseProduction * productionMultiplier * parameterEfficiency;
+  }, [baseProduction, productionMultiplier, parameterEfficiency]);
+
+  const unlockedZones = useMemo(
+    () => FRACTAL_ZONES.filter((zone) => depth >= zone.requirement),
+    [depth],
+  );
+
+  const currentZone = unlockedZones[unlockedZones.length - 1] ?? FRACTAL_ZONES[0];
+
+  const zoneBonus = currentZone ? 1 + currentZone.bonus : 1;
+
+  const effectiveDataPerSecond = dataPerSecond * zoneBonus;
+
+  const passiveDepthGain = useMemo(() => {
+    if (upgrades.stabilizer <= 0) {
+      return 0;
+    }
+    return (0.06 + upgrades.stabilizer * 0.025) * parameterEfficiency;
+  }, [parameterEfficiency, upgrades.stabilizer]);
+
+  useEffect(() => {
+    if (effectiveDataPerSecond <= 0 && passiveDepthGain <= 0) {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      if (effectiveDataPerSecond > 0) {
+        setFractalData((previous) => previous + effectiveDataPerSecond / 2);
+      }
+      if (passiveDepthGain > 0) {
+        setDepth((previous) => previous + passiveDepthGain / 2);
+      }
+    }, 500);
+
+    return () => window.clearInterval(interval);
+  }, [effectiveDataPerSecond, passiveDepthGain]);
+
+  useEffect(() => {
+    if (!currentZone || currentZone.name === lastZone) {
+      return;
+    }
+    pushLog(`New region unlocked: ${currentZone.name}. ${currentZone.description}`);
+    setLastZone(currentZone.name);
+  }, [currentZone, lastZone, pushLog]);
+
+  const handleZoomDeeper = useCallback(() => {
+    let zoomApproved = false;
+    setFractalData((previous) => {
+      if (previous < zoomCost) {
+        return previous;
+      }
+      zoomApproved = true;
+      return previous - zoomCost;
+    });
+    if (zoomApproved) {
+      setDepth((previous) => {
+        const updated = previous + 1;
+        pushLog(`Zoomed to depth ${Math.floor(updated)}. Details blossom.`);
+        return updated;
+      });
+    } else {
+      pushLog("Insufficient Fractal Data to penetrate deeper.");
+    }
+  }, [pushLog, zoomCost]);
+
+  const handleZoomOut = useCallback(() => {
+    setDepth((previous) => Math.max(0, previous - 1));
+    pushLog("Stabilised view at a safer zoom.");
+  }, [pushLog]);
+
+  const handleUpgradePurchase = useCallback(
+    (key: UpgradeKey) => {
+      const cost = upgradeCost(key);
+      let purchase = false;
+      setFractalData((previous) => {
+        if (previous < cost) {
+          return previous;
+        }
+        purchase = true;
+        return previous - cost;
+      });
+      if (!purchase) {
+        pushLog("The frontier demands more data before that upgrade.");
+        return;
+      }
+      setUpgrades((previous) => ({ ...previous, [key]: previous[key] + 1 }));
+      pushLog(`Upgrade secured: ${UPGRADE_CONFIG[key].title}.`);
+    },
+    [pushLog, upgradeCost],
+  );
+
+  const ascendReady = depth >= 6 && fractalData >= 1200;
+  const ascensionYield = useMemo(() => {
+    const depthContribution = Math.floor(Math.max(depth, 0));
+    const dataContribution = Math.floor(fractalData / 400);
+    const total = depthContribution + dataContribution + upgrades.processor;
+    return Math.max(1, Math.floor(total * 0.75));
+  }, [depth, fractalData, upgrades.processor]);
+
+  const handleAscend = useCallback(() => {
+    if (!ascendReady) {
+      pushLog("The fractal resists ascension – reach deeper detail first.");
+      return;
+    }
+    setDimensionalPoints((previous) => previous + ascensionYield);
+    setAscensionLevel((previous) => previous + 1);
+    setFractalData(40 + ascensionYield * 15);
+    setDepth(0);
+    setUpgrades({ probe: 0, processor: 0, stabilizer: 0 });
+    setAmplifiers(0);
+    pushLog(`Dimensional Ascension complete. Gained ${ascensionYield} Dimensional Points.`);
+  }, [ascendReady, ascensionYield, pushLog]);
+
+  const amplifierCost = useMemo(
+    () => Math.floor(3 * Math.pow(2.4, amplifiers)),
+    [amplifiers],
+  );
+
+  const handleAmplifierPurchase = useCallback(() => {
+    let purchase = false;
+    setDimensionalPoints((previous) => {
+      if (previous < amplifierCost) {
+        return previous;
+      }
+      purchase = true;
+      return previous - amplifierCost;
+    });
+    if (!purchase) {
+      pushLog("Need more Dimensional Points to stabilise an amplifier.");
+      return;
+    }
+    setAmplifiers((previous) => previous + 1);
+    pushLog("Dimensional Amplifier anchors permanent insight.");
+  }, [amplifierCost, pushLog]);
+
+  const handleParameterChange = useCallback(
+    (changes: Partial<ComplexParameter>) => {
+      setComplexParameter((previous) => ({ ...previous, ...changes }));
+    },
+    [],
+  );
+
+  const dimensionalEfficiency = (parameterEfficiency * 100).toFixed(0);
+
+  return (
+    <Box className="startherebox">
+      <StartHereMenu
+        fractalData={fractalData}
+        depth={depth}
+        dataPerSecond={effectiveDataPerSecond}
+        dimensionalPoints={dimensionalPoints}
+      />
+      <Grid className="starthere-grid" columns={{ initial: "1", md: "2" }} gap="4">
+        <Flex direction="column" gap="4">
+          <Card className="fractal-card">
+            <Flex justify="between" align="center" mb="3">
+              <Heading size="4">Fractal Frontier</Heading>
+              <Text size="2" color="mint">
+                Zone bonus: +{Math.round((zoneBonus - 1) * 100)}%
+              </Text>
+            </Flex>
+            <FractalViewer depth={depth} parameter={complexParameter} amplifiers={amplifiers} />
+            <Separator my="3" size="4" />
+            <Grid columns={{ initial: "1", sm: "2" }} gap="4">
+              <Card className="control-card">
+                <Heading size="3">Manual Navigation</Heading>
+                <Text color="gray" size="2" mb="3">
+                  Each zoom consumes Fractal Data but reveals exponentially richer structures.
+                </Text>
+                <Flex gap="3" mb="3" wrap="wrap">
+                  <Button onClick={handleZoomDeeper} color="green">
+                    Zoom Deeper (Cost: {formatNumber(zoomCost)})
+                  </Button>
+                  <Button onClick={handleZoomOut} variant="soft" color="gray">
+                    Ease Out
+                  </Button>
+                </Flex>
+                <Text size="2" color="gray">
+                  Passive stabilisers add {passiveDepthGain.toFixed(2)} depth / sec when active.
+                </Text>
+              </Card>
+              <Card className="control-card">
+                <Heading size="3">Complex Parameter Tuning</Heading>
+                <Text size="2" color="gray">
+                  Align with the sweet spot (c = -0.75 + 0.11i) to maximise efficiency.
+                </Text>
+                <Box className="slider-group">
+                  <Text weight="medium">Real: {complexParameter.real.toFixed(2)}</Text>
+                  <Slider
+                    min={-2}
+                    max={1}
+                    step={0.01}
+                    value={[complexParameter.real]}
+                    onValueChange={([value]) => handleParameterChange({ real: value })}
+                  />
+                </Box>
+                <Box className="slider-group">
+                  <Text weight="medium">Imaginary: {complexParameter.imaginary.toFixed(2)}i</Text>
+                  <Slider
+                    min={-1}
+                    max={1}
+                    step={0.01}
+                    value={[complexParameter.imaginary]}
+                    onValueChange={([value]) => handleParameterChange({ imaginary: value })}
+                  />
+                </Box>
+                <Text size="2" color="mint">
+                  Dimensional efficiency: {dimensionalEfficiency}%
+                </Text>
+              </Card>
+            </Grid>
+          </Card>
+          <Card className="zone-card">
+            <Heading size="4">Exploration Zones</Heading>
+            <Text size="2" color="gray">
+              Deeper zooms reveal new fractal biomes. Each grants a unique production bonus.
+            </Text>
+            <Separator my="3" size="4" />
+            <Flex direction="column" gap="3">
+              {FRACTAL_ZONES.map((zone) => {
+                const unlocked = depth >= zone.requirement;
+                return (
+                  <Card key={zone.name} className={`zone-entry ${unlocked ? "zone-unlocked" : "zone-locked"}`}>
+                    <Flex justify="between" align="center" mb="1">
+                      <Heading size="3">{zone.name}</Heading>
+                      <Text size="2" color={unlocked ? "mint" : "gray"}>
+                        {unlocked ? "Unlocked" : `Depth ${zone.requirement}`}
+                      </Text>
+                    </Flex>
+                    <Text size="2" color="gray">
+                      {zone.description}
+                    </Text>
+                    <Text size="2" color="mint">
+                      Bonus: +{Math.round(zone.bonus * 100)}% production
+                    </Text>
+                  </Card>
+                );
+              })}
+            </Flex>
+          </Card>
+        </Flex>
+        <Flex direction="column" gap="4">
+          <Card className="upgrade-card">
+            <Heading size="4" mb="1">
+              Automation Upgrades
+            </Heading>
+            <Text size="2" color="gray">
+              Invest Fractal Data to automate exploration. Each stack compounds with your dimensional bonuses.
+            </Text>
+            <Separator my="3" size="4" />
+            <Flex direction="column" gap="3">
+              {Object.entries(UPGRADE_CONFIG).map(([key, config]) => {
+                const typedKey = key as UpgradeKey;
+                const owned = upgrades[typedKey];
+                const cost = upgradeCost(typedKey);
+                return (
+                  <Card key={key} className="upgrade-row">
+                    <Flex justify="between" align="center" mb="2">
+                      <Heading size="3">{config.title}</Heading>
+                      <Text size="2" color="gray">
+                        Owned: {owned}
+                      </Text>
+                    </Flex>
+                    <Text size="2" color="gray">
+                      {config.description}
+                    </Text>
+                    <Text size="2" color="mint" mb="2">
+                      {config.flavor}
+                    </Text>
+                    <Button onClick={() => handleUpgradePurchase(typedKey)}>
+                      Purchase ({formatNumber(cost)} Data)
+                    </Button>
+                  </Card>
+                );
+              })}
+            </Flex>
+          </Card>
+          <Card className="prestige-card">
+            <Heading size="4" mb="1">
+              Dimensional Ascension
+            </Heading>
+            <Text size="2" color="gray">
+              Collapse the current fractal and start anew with permanent insight. Costs your progress but grants Dimensional Points.
+            </Text>
+            <Separator my="3" size="4" />
+            <Flex align="center" justify="between" mb="3">
+              <Box>
+                <Text size="2">Ascension yield: {ascensionYield} DP</Text>
+                <Text size="2" color={ascendReady ? "mint" : "gray"}>
+                  Status: {ascendReady ? "Ready" : "Not yet"}
+                </Text>
+              </Box>
+              <Button onClick={handleAscend} color={ascendReady ? "purple" : "gray"} variant={ascendReady ? "solid" : "soft"}>
+                Ascend
+              </Button>
+            </Flex>
+            <Box className="prestige-upgrades">
+              <Heading size="3">Dimensional Amplifiers</Heading>
+              <Text size="2" color="gray">
+                Spend Dimensional Points for permanent production boosts that survive resets.
+              </Text>
+              <Flex align="center" justify="between" mt="2">
+                <Text size="2">Amplifiers owned: {amplifiers}</Text>
+                <Button onClick={handleAmplifierPurchase} variant="soft" color="mint">
+                  Buy ({amplifierCost} DP)
+                </Button>
+              </Flex>
+            </Box>
+          </Card>
+          <Card className="log-card">
+            <Heading size="4" mb="2">
+              Mission Log
+            </Heading>
+            <Flex direction="column" gap="2">
+              {activityLog.map((entry, index) => (
+                <Text key={`${entry}-${index}`} size="2" color={index === 0 ? "mint" : "gray"}>
+                  {entry}
+                </Text>
+              ))}
+            </Flex>
+          </Card>
+        </Flex>
+      </Grid>
+    </Box>
+  );
 }

--- a/src/app/pages/startheremenu.tsx
+++ b/src/app/pages/startheremenu.tsx
@@ -1,14 +1,69 @@
 import type { ReactElement } from "react";
-import {Flex,Grid,Text} from "@radix-ui/themes";
 
-export default function StartHereMenu():ReactElement{
-    return(
-        <Flex>
-            <Grid columns="3" width="100%">
-                <Text>Menu1</Text>
-                <Text>Menu2</Text>
-                <Text>Menu3</Text>
-            </Grid>
-        </Flex>
-    );
+import { Badge, Flex, Grid, Heading, Text } from "@radix-ui/themes";
+
+type StartHereMenuProps = {
+  fractalData: number;
+  depth: number;
+  dataPerSecond: number;
+  dimensionalPoints: number;
+};
+
+const formatCompactNumber = (value: number): string => {
+  if (value >= 1e9) {
+    return `${(value / 1e9).toFixed(2)}B`;
+  }
+  if (value >= 1e6) {
+    return `${(value / 1e6).toFixed(2)}M`;
+  }
+  if (value >= 1e3) {
+    return `${(value / 1e3).toFixed(2)}K`;
+  }
+  return value.toFixed(0);
+};
+
+export default function StartHereMenu({
+  fractalData,
+  depth,
+  dataPerSecond,
+  dimensionalPoints,
+}: StartHereMenuProps): ReactElement {
+  return (
+    <Flex className="starthere-menu" align="center" justify="between" wrap="wrap">
+      <Heading size="5" className="menu-title">
+        Fractal Frontier Control Deck
+      </Heading>
+      <Grid columns={{ initial: "1", sm: "2", md: "4" }} gap="3" width="auto">
+        <StatBadge label="Fractal Data" value={`${formatCompactNumber(fractalData)} units`} accent="mint" />
+        <StatBadge
+          label="Data / sec"
+          value={`${formatCompactNumber(dataPerSecond)} /s`}
+          accent="cyan"
+        />
+        <StatBadge label="Zoom Depth" value={depth.toFixed(2)} accent="iris" />
+        <StatBadge
+          label="Dimensional Points"
+          value={dimensionalPoints.toFixed(0)}
+          accent={dimensionalPoints > 0 ? "purple" : "gray"}
+        />
+      </Grid>
+    </Flex>
+  );
+}
+
+type StatBadgeProps = {
+  label: string;
+  value: string;
+  accent: "mint" | "cyan" | "iris" | "purple" | "gray";
+};
+
+function StatBadge({ label, value, accent }: StatBadgeProps): ReactElement {
+  return (
+    <Flex direction="column" gap="1">
+      <Text size="1" color="gray">{label}</Text>
+      <Badge color={accent} size="3">
+        {value}
+      </Badge>
+    </Flex>
+  );
 }

--- a/src/styles/starthere.css
+++ b/src/styles/starthere.css
@@ -1,3 +1,141 @@
 @import "tailwindcss";
 
+.startherebox {
+  min-height: 100vh;
+  padding: 2rem 1.5rem 3rem;
+  background: radial-gradient(circle at top, rgba(64, 224, 208, 0.08), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(139, 92, 246, 0.08), transparent 45%),
+    radial-gradient(circle at bottom left, rgba(56, 189, 248, 0.06), transparent 40%),
+    #050510;
+  color: var(--gray-12);
+}
+
+.starthere-grid {
+  width: 100%;
+  margin-top: 1.5rem;
+}
+
+.starthere-menu {
+  padding: 1.5rem 2rem;
+  background: linear-gradient(90deg, rgba(41, 37, 82, 0.8), rgba(15, 118, 110, 0.55));
+  border-radius: 20px;
+  box-shadow: 0 12px 30px rgba(5, 5, 40, 0.45);
+  gap: 1.5rem;
+}
+
+.starthere-menu .menu-title {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--mint-9);
+}
+
+.fractal-card,
+.zone-card,
+.upgrade-card,
+.prestige-card,
+.log-card,
+.control-card,
+.zone-entry,
+.upgrade-row {
+  background: rgba(12, 12, 28, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(120, 119, 198, 0.15);
+  box-shadow: 0 16px 30px rgba(9, 9, 26, 0.35);
+}
+
+.fractal-card {
+  padding: 1.75rem;
+}
+
+.control-card {
+  padding: 1.25rem;
+}
+
+.zone-card,
+.upgrade-card,
+.prestige-card,
+.log-card {
+  padding: 1.5rem;
+}
+
+.fractal-canvas {
+  width: 100%;
+  height: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  background: radial-gradient(circle at center, rgba(148, 163, 184, 0.12), transparent 70%);
+  margin-bottom: 1.25rem;
+}
+
+.slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.slider-group .rt-SliderRoot {
+  height: 0.75rem;
+}
+
+.slider-group .rt-SliderRange {
+  background: linear-gradient(90deg, var(--cyan-8), var(--mint-9));
+}
+
+.slider-group .rt-SliderThumb {
+  width: 18px;
+  height: 18px;
+}
+
+.zone-entry {
+  padding: 1.25rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.zone-entry.zone-unlocked {
+  border-color: rgba(110, 231, 183, 0.35);
+  transform: translateY(-3px);
+}
+
+.zone-entry.zone-locked {
+  opacity: 0.65;
+}
+
+.upgrade-row {
+  padding: 1.25rem;
+}
+
+.prestige-upgrades {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(30, 41, 59, 0.5);
+  border: 1px solid rgba(94, 234, 212, 0.18);
+}
+
+.log-card {
+  min-height: 220px;
+}
+
+.log-card .rt-Text:first-child {
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .startherebox {
+    padding: 1.5rem;
+  }
+
+  .starthere-menu {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .fractal-card,
+  .zone-card,
+  .upgrade-card,
+  .prestige-card,
+  .log-card {
+    padding: 1.25rem;
+  }
+}
 


### PR DESCRIPTION
## Summary
- build the Fractal Frontier experience with a live Mandelbrot-inspired canvas, manual zoom controls, and zone unlock tracking
- add automation, ascension, and dimensional amplifier management with activity logging and resource formatting
- style the control deck, upgrade panels, and mission log to match the new exploration theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5abab2480832a8292f2c3f740c469