### PR TITLE
Add cosmic events and polish to StartHere gameplay

### DIFF
--- a/memory/tasks/TASK009-enhance-gameplay-and-visuals.md
+++ b/memory/tasks/TASK009-enhance-gameplay-and-visuals.md
@@ -1,0 +1,44 @@
+# TASK009 - Enhance Gameplay and Visuals
+
+**Status:** In Progress
+**Added:** 2025-10-10
+**Updated:** 2025-10-10
+
+## Original Request
+
+Enhance gameplay and visuals, make fun assumptions and implement fully.
+
+## Thought Process
+
+The project currently lacks engaging gameplay loops and polished visuals. I'll build on the fractal exploration concept by introducing whimsical lore (e.g., cosmic cartographers), add core interactive mechanics (resource generation, upgrades, events), and enhance visuals with animated backgrounds and responsive UI feedback. The focus will stay aligned with the fractal exploration theme while providing a playful tone.
+
+## Implementation Plan
+
+- [x] Audit existing components to identify extension points for gameplay features and styling.
+- [x] Implement a whimsical resource and event system that makes the fractal frontier feel alive.
+- [x] Add visual polish (animations, gradients, thematic styling) to reinforce the narrative.
+- [x] Update UI components/pages to surface new mechanics and feedback loops.
+- [x] Add automated tests covering new logic and rendering expectations.
+
+## Progress Tracking
+
+**Overall Status:** Completed - 100%
+
+### Subtasks
+
+| ID  | Description                                                     | Status        | Updated    | Notes |
+| --- | --------------------------------------------------------------- | ------------- | ---------- | ----- |
+| 9.1 | Identify components requiring gameplay & visual enhancements    | Complete      | 2025-10-10 | Mapped StartHere layout for new systems. |
+| 9.2 | Implement resource/event mechanics with whimsical assumptions   | Complete      | 2025-10-10 | Added resonance/anomaly systems and cosmic events. |
+| 9.3 | Enhance UI styling and animations for fractal exploration theme | Complete      | 2025-10-10 | Introduced animated aurora background and cosmic meters. |
+| 9.4 | Update pages/components to surface new mechanics                 | Complete      | 2025-10-10 | Built Cosmic Forecast card and menu stats. |
+| 9.5 | Add/update tests for new logic and visuals                       | Complete      | 2025-10-10 | Added cosmic event unit tests and config updates. |
+
+## Progress Log
+
+### 2025-10-10
+
+- Created task outlining gameplay and visual enhancement goals.
+- Logged initial plan and subtasks to guide implementation.
+- Implemented cosmic events, resonance/anomaly mechanics, and expedition actions with animated UI polish.
+- Expanded StartHere menu stats, added automated tests, and configured Vitest to ignore Playwright specs.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -17,6 +17,7 @@
 ## Completed
 
 - [TASK000] Project setup and Memory Bank creation - Completed on October 8, 2025
+- [TASK009] Enhance gameplay and visuals - Completed on October 10, 2025
 
 ## Abandoned
 

--- a/src/app/pages/cosmicEvents.ts
+++ b/src/app/pages/cosmicEvents.ts
@@ -1,0 +1,178 @@
+export type CosmicSnapshot = {
+  depth: number;
+  resonance: number;
+  anomalies: number;
+  ascensionLevel: number;
+  dimensionalPoints: number;
+};
+
+export type CosmicEventOutcome = {
+  log: string;
+  dataDelta?: number;
+  resonanceDelta?: number;
+  anomaliesDelta?: number;
+  depthDelta?: number;
+  dimensionalPointsDelta?: number;
+};
+
+export type CosmicEvent = {
+  id: string;
+  name: string;
+  description: string;
+  minDepth?: number;
+  minResonance?: number;
+  weight: number;
+  apply: (snapshot: CosmicSnapshot) => CosmicEventOutcome;
+};
+
+const clampWeight = (value: number): number => (value > 0 ? value : 0.5);
+
+export const COSMIC_EVENTS: CosmicEvent[] = [
+  {
+    id: "cantor-caravan",
+    name: "Cantor Caravan",
+    description: "Nomadic archivists deliver annotated caches of fractal lore.",
+    weight: 3.2,
+    apply: (snapshot) => {
+      const dataGain = Math.round(
+        60 + snapshot.depth * 12 + snapshot.resonance * 4,
+      );
+      return {
+        dataDelta: dataGain,
+        resonanceDelta: 1,
+        log: `Nomadic archivists deposit ${dataGain} units of annotated detail.`,
+      };
+    },
+  },
+  {
+    id: "sierpinski-storm",
+    name: "Sierpinski Storm",
+    description:
+      "Triangular lightning scrambles collectors but energises the air.",
+    weight: 2.1,
+    apply: (snapshot) => {
+      const lost = Math.round(30 + snapshot.depth * 8);
+      const resonanceGain = 3 + Math.round(snapshot.anomalies * 0.5);
+      return {
+        dataDelta: -lost,
+        resonanceDelta: resonanceGain,
+        anomaliesDelta: 1,
+        log: `Triangular lightning scatters ${lost} data but leaves ${resonanceGain} resonance crackling.`,
+      };
+    },
+  },
+  {
+    id: "hilbert-scouts",
+    name: "Hilbert Scout Fleet",
+    description:
+      "Space-filling drones weave shortcuts between zoom coordinates.",
+    minDepth: 4,
+    weight: 2,
+    apply: (snapshot) => {
+      const depthGain = 0.4 + snapshot.ascensionLevel * 0.1;
+      const anomalyDrop = snapshot.anomalies > 0 ? -1 : 0;
+      return {
+        depthDelta: depthGain,
+        anomaliesDelta: anomalyDrop,
+        log: `Scouts weave Hilbert paths, mapping +${depthGain.toFixed(2)} depth${
+          anomalyDrop ? " and calming an anomaly" : ""
+        }.`,
+      };
+    },
+  },
+  {
+    id: "lighthouse-of-julia",
+    name: "Lighthouse of Julia",
+    description: "A coherent beacon aligns the expedition across dimensions.",
+    minDepth: 6,
+    minResonance: 6,
+    weight: 1.4,
+    apply: (snapshot) => {
+      const resonanceGain = 4 + Math.round(snapshot.ascensionLevel * 1.5);
+      const dataGain = Math.round(85 + snapshot.resonance * 2);
+      return {
+        dataDelta: dataGain,
+        resonanceDelta: resonanceGain,
+        log: `The Julia lighthouse flares, granting ${resonanceGain} resonance and ${dataGain} data.`,
+      };
+    },
+  },
+  {
+    id: "paradox-auditors",
+    name: "Paradox Auditors",
+    description: "The Bureau of Recursive Integrity pays a surprise visit.",
+    minDepth: 2,
+    weight: 1.1,
+    apply: (snapshot) => {
+      const removedAnomalies = Math.min(snapshot.anomalies, 2);
+      const dpGain = removedAnomalies > 0 ? removedAnomalies : 0;
+      return {
+        anomaliesDelta: -removedAnomalies,
+        dimensionalPointsDelta: dpGain,
+        log:
+          removedAnomalies > 0
+            ? `Auditors resolve ${removedAnomalies} anomaly${removedAnomalies > 1 ? "ies" : ""}, refunding ${dpGain} Dimensional Points.`
+            : "Auditors find nothing amiss but leave amused by your paperwork.",
+      };
+    },
+  },
+  {
+    id: "temporal-tea-time",
+    name: "Temporal Tea Time",
+    description: "Chrono-sommeliers trade tea steeped in infinite loops.",
+    minResonance: 3,
+    weight: 1.6,
+    apply: (snapshot) => {
+      const resonanceSpend = Math.min(snapshot.resonance, 2);
+      const dataGain = resonanceSpend > 0 ? 40 + resonanceSpend * 30 : 22;
+      return {
+        resonanceDelta: -resonanceSpend,
+        dataDelta: dataGain,
+        log: `Temporal tea steeps for ${resonanceSpend} resonance and condenses ${dataGain} data crystals.`,
+      };
+    },
+  },
+];
+
+const meetsRequirement = (
+  snapshot: CosmicSnapshot,
+  event: CosmicEvent,
+): boolean => {
+  if (typeof event.minDepth === "number" && snapshot.depth < event.minDepth) {
+    return false;
+  }
+  if (
+    typeof event.minResonance === "number" &&
+    snapshot.resonance < event.minResonance
+  ) {
+    return false;
+  }
+  return true;
+};
+
+export const resolveCosmicEvent = (
+  snapshot: CosmicSnapshot,
+  random: () => number = Math.random,
+): { event: CosmicEvent; outcome: CosmicEventOutcome } => {
+  const eligible = COSMIC_EVENTS.filter((event) =>
+    meetsRequirement(snapshot, event),
+  );
+  const pool = eligible.length > 0 ? eligible : [COSMIC_EVENTS[0]];
+  const totalWeight = pool.reduce(
+    (sum, event) => sum + clampWeight(event.weight),
+    0,
+  );
+  const target = random() * (totalWeight > 0 ? totalWeight : pool.length);
+
+  let cumulative = 0;
+  let selected = pool[0];
+  for (const event of pool) {
+    cumulative += clampWeight(event.weight);
+    if (target <= cumulative) {
+      selected = event;
+      break;
+    }
+  }
+
+  return { event: selected, outcome: selected.apply(snapshot) };
+};

--- a/src/app/pages/starthere.tsx
+++ b/src/app/pages/starthere.tsx
@@ -1,14 +1,26 @@
-'use client';
+"use client";
 
 import "@/styles/starthere.css";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
 
-import { Box, Button, Card, Flex, Grid, Heading, Separator, Slider, Text } from "@radix-ui/themes";
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Grid,
+  Heading,
+  Separator,
+  Slider,
+  Text,
+} from "@radix-ui/themes";
 
 import FractalViewer from "./fractalviewer";
 import StartHereMenu from "./startheremenu";
+import { resolveCosmicEvent } from "./cosmicEvents";
 
 type UpgradeKey = "probe" | "processor" | "stabilizer";
 
@@ -28,21 +40,24 @@ type UpgradeConfig = {
 const UPGRADE_CONFIG: Record<UpgradeKey, UpgradeConfig> = {
   probe: {
     title: "Fractal Probes",
-    description: "Deploy autonomous explorers that map detail while you plan the next zoom.",
+    description:
+      "Deploy autonomous explorers that map detail while you plan the next zoom.",
     baseCost: 35,
     growth: 1.45,
     flavor: "Their quantum lenses never blink.",
   },
   processor: {
     title: "Quantum Processors",
-    description: "Accelerate every calculation, multiplying the insight gathered by your probes.",
+    description:
+      "Accelerate every calculation, multiplying the insight gathered by your probes.",
     baseCost: 120,
     growth: 1.6,
     flavor: "The algorithms hum in complex harmony.",
   },
   stabilizer: {
     title: "Dimensional Stabilizers",
-    description: "Anchor deeper zoom levels so the structure holds while automation continues.",
+    description:
+      "Anchor deeper zoom levels so the structure holds while automation continues.",
     baseCost: 220,
     growth: 1.55,
     flavor: "Reality threads itself tighter around the frontier.",
@@ -60,25 +75,29 @@ const FRACTAL_ZONES = [
     name: "Seahorse Valley",
     requirement: 4,
     bonus: 0.08,
-    description: "Filigree spirals curl like cosmic seahorses, enriching every data packet.",
+    description:
+      "Filigree spirals curl like cosmic seahorses, enriching every data packet.",
   },
   {
     name: "Spiral Nebula",
     requirement: 7,
     bonus: 0.18,
-    description: "Twin galaxies of recursion feed each other, boosting production dramatically.",
+    description:
+      "Twin galaxies of recursion feed each other, boosting production dramatically.",
   },
   {
     name: "Mini-Brot Frontier",
     requirement: 11,
     bonus: 0.3,
-    description: "Self-similarity upon self-similarity. You glimpse new universes in each pixel.",
+    description:
+      "Self-similarity upon self-similarity. You glimpse new universes in each pixel.",
   },
   {
     name: "Hyperbolic Bloom",
     requirement: 15,
     bonus: 0.45,
-    description: "Geometries bloom beyond Euclid. Ascension-grade knowledge saturates every line.",
+    description:
+      "Geometries bloom beyond Euclid. Ascension-grade knowledge saturates every line.",
   },
 ];
 
@@ -108,13 +127,27 @@ export default function StartHere(): ReactElement {
   const [dimensionalPoints, setDimensionalPoints] = useState<number>(0);
   const [ascensionLevel, setAscensionLevel] = useState<number>(0);
   const [amplifiers, setAmplifiers] = useState<number>(0);
+  const [resonance, setResonance] = useState<number>(4);
+  const [anomalies, setAnomalies] = useState<number>(0);
+  const [expeditionRank, setExpeditionRank] = useState<number>(0);
+  const [eventCountdown, setEventCountdown] = useState<number>(18);
   const [complexParameter, setComplexParameter] = useState<ComplexParameter>({
     ...DIMENSIONAL_TARGET,
   });
   const [activityLog, setActivityLog] = useState<string[]>([
     "Begin exploration: calibrating renderers…",
   ]);
-  const [lastZone, setLastZone] = useState<string>(FRACTAL_ZONES[0]?.name ?? "");
+  const [lastZone, setLastZone] = useState<string>(
+    FRACTAL_ZONES[0]?.name ?? "",
+  );
+  const latestSnapshotRef = useRef({
+    depth,
+    resonance,
+    anomalies,
+    ascensionLevel,
+    dimensionalPoints,
+    fractalData,
+  });
 
   const pushLog = useCallback((message: string) => {
     setActivityLog((previous) => [message, ...previous].slice(0, 6));
@@ -139,8 +172,23 @@ export default function StartHere(): ReactElement {
     const ascensionBonus = 1 + ascensionLevel * 0.25 + amplifiers * 0.35;
     const depthBonus = 1 + Math.floor(depth) * 0.05;
     const dimensionalBonus = 1 + dimensionalPoints * 0.02;
-    return ascensionBonus * depthBonus * dimensionalBonus;
-  }, [ascensionLevel, amplifiers, depth, dimensionalPoints]);
+    const resonanceBonus = 1 + resonance * 0.015;
+    const anomalyPenalty = Math.max(0.6, 1 - anomalies * 0.03);
+    return (
+      ascensionBonus *
+      depthBonus *
+      dimensionalBonus *
+      resonanceBonus *
+      anomalyPenalty
+    );
+  }, [
+    ascensionLevel,
+    amplifiers,
+    anomalies,
+    depth,
+    dimensionalPoints,
+    resonance,
+  ]);
 
   const parameterEfficiency = useMemo(() => {
     const distance = Math.hypot(
@@ -169,7 +217,8 @@ export default function StartHere(): ReactElement {
     [depth],
   );
 
-  const currentZone = unlockedZones[unlockedZones.length - 1] ?? FRACTAL_ZONES[0];
+  const currentZone =
+    unlockedZones[unlockedZones.length - 1] ?? FRACTAL_ZONES[0];
 
   const zoneBonus = currentZone ? 1 + currentZone.bonus : 1;
 
@@ -179,8 +228,47 @@ export default function StartHere(): ReactElement {
     if (upgrades.stabilizer <= 0) {
       return 0;
     }
-    return (0.06 + upgrades.stabilizer * 0.025) * parameterEfficiency;
-  }, [parameterEfficiency, upgrades.stabilizer]);
+    const resonanceAssist = 1 + Math.min(resonance * 0.02, 0.6);
+    return (
+      (0.06 + upgrades.stabilizer * 0.025) *
+      parameterEfficiency *
+      resonanceAssist
+    );
+  }, [parameterEfficiency, resonance, upgrades.stabilizer]);
+
+  const expeditionCost = useMemo(
+    () =>
+      Math.floor(90 + depth * 25 + ascensionLevel * 35 + expeditionRank * 20),
+    [ascensionLevel, depth, expeditionRank],
+  );
+
+  const expeditionPreview = useMemo(
+    () => Math.floor(6 + depth * 0.6 + resonance * 0.3 + ascensionLevel * 1.5),
+    [ascensionLevel, depth, resonance],
+  );
+
+  const stabiliseCost = useMemo(
+    () => Math.floor(24 + anomalies * 9 + ascensionLevel * 6),
+    [anomalies, ascensionLevel],
+  );
+
+  useEffect(() => {
+    latestSnapshotRef.current = {
+      depth,
+      resonance,
+      anomalies,
+      ascensionLevel,
+      dimensionalPoints,
+      fractalData,
+    };
+  }, [
+    anomalies,
+    ascensionLevel,
+    depth,
+    dimensionalPoints,
+    fractalData,
+    resonance,
+  ]);
 
   useEffect(() => {
     if (effectiveDataPerSecond <= 0 && passiveDepthGain <= 0) {
@@ -203,9 +291,54 @@ export default function StartHere(): ReactElement {
     if (!currentZone || currentZone.name === lastZone) {
       return;
     }
-    pushLog(`New region unlocked: ${currentZone.name}. ${currentZone.description}`);
+    pushLog(
+      `New region unlocked: ${currentZone.name}. ${currentZone.description}`,
+    );
     setLastZone(currentZone.name);
   }, [currentZone, lastZone, pushLog]);
+
+  const triggerCosmicEvent = useCallback(() => {
+    const { event, outcome } = resolveCosmicEvent(latestSnapshotRef.current);
+    if (outcome.dataDelta && outcome.dataDelta !== 0) {
+      setFractalData((previous) => Math.max(0, previous + outcome.dataDelta));
+    }
+    if (outcome.resonanceDelta && outcome.resonanceDelta !== 0) {
+      setResonance((previous) =>
+        Math.max(0, previous + outcome.resonanceDelta),
+      );
+    }
+    if (outcome.anomaliesDelta && outcome.anomaliesDelta !== 0) {
+      setAnomalies((previous) =>
+        Math.max(0, previous + outcome.anomaliesDelta),
+      );
+    }
+    if (outcome.depthDelta && outcome.depthDelta !== 0) {
+      setDepth((previous) => Math.max(0, previous + outcome.depthDelta));
+    }
+    if (
+      outcome.dimensionalPointsDelta &&
+      outcome.dimensionalPointsDelta !== 0
+    ) {
+      setDimensionalPoints((previous) =>
+        Math.max(0, previous + outcome.dimensionalPointsDelta),
+      );
+    }
+    pushLog(`[Event] ${event.name}: ${outcome.log}`);
+  }, [pushLog]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setEventCountdown((previous) => {
+        if (previous <= 1) {
+          triggerCosmicEvent();
+          return 16 + Math.floor(Math.random() * 9);
+        }
+        return previous - 1;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [triggerCosmicEvent]);
 
   const handleZoomDeeper = useCallback(() => {
     let zoomApproved = false;
@@ -231,6 +364,59 @@ export default function StartHere(): ReactElement {
     setDepth((previous) => Math.max(0, previous - 1));
     pushLog("Stabilised view at a safer zoom.");
   }, [pushLog]);
+
+  const handleExpedition = useCallback(() => {
+    let authorised = false;
+    setFractalData((previous) => {
+      if (previous < expeditionCost) {
+        return previous;
+      }
+      authorised = true;
+      return previous - expeditionCost;
+    });
+    if (!authorised) {
+      pushLog("Expedition denied: insufficient Fractal Data for launch.");
+      return;
+    }
+    const variableReward = expeditionPreview + Math.floor(Math.random() * 4);
+    setResonance((previous) => previous + variableReward);
+    setDepth((previous) => previous + 0.25);
+    setExpeditionRank((previous) => previous + 1);
+    if (Math.random() > 0.72) {
+      setAnomalies((previous) => previous + 1);
+      pushLog(
+        `Expedition reports ${variableReward} resonance shards and an excitable anomaly hitchhiker.`,
+      );
+      return;
+    }
+    pushLog(
+      `Expedition returns triumphantly with ${variableReward} resonance shards.`,
+    );
+  }, [expeditionCost, expeditionPreview, pushLog]);
+
+  const handleStabiliseAnomaly = useCallback(() => {
+    if (anomalies <= 0) {
+      pushLog("Calibration steady: no anomalies demand stabilisation.");
+      return;
+    }
+    let authorised = false;
+    setFractalData((previous) => {
+      if (previous < stabiliseCost) {
+        return previous;
+      }
+      authorised = true;
+      return previous - stabiliseCost;
+    });
+    if (!authorised) {
+      pushLog(
+        "Stabilisation cancelled: gather more Fractal Data for the ritual.",
+      );
+      return;
+    }
+    setAnomalies((previous) => Math.max(0, previous - 1));
+    setResonance((previous) => previous + 2);
+    pushLog("Quantum botanists prune an anomaly garden into calm symmetry.");
+  }, [anomalies, pushLog, stabiliseCost]);
 
   const handleUpgradePurchase = useCallback(
     (key: UpgradeKey) => {
@@ -272,7 +458,15 @@ export default function StartHere(): ReactElement {
     setDepth(0);
     setUpgrades({ probe: 0, processor: 0, stabilizer: 0 });
     setAmplifiers(0);
-    pushLog(`Dimensional Ascension complete. Gained ${ascensionYield} Dimensional Points.`);
+    setResonance((previous) =>
+      Math.max(3, Math.floor(previous * 0.35) + ascensionYield),
+    );
+    setAnomalies(0);
+    setEventCountdown(18);
+    setExpeditionRank(0);
+    pushLog(
+      `Dimensional Ascension complete. Gained ${ascensionYield} Dimensional Points.`,
+    );
   }, [ascendReady, ascensionYield, pushLog]);
 
   const amplifierCost = useMemo(
@@ -305,6 +499,21 @@ export default function StartHere(): ReactElement {
   );
 
   const dimensionalEfficiency = (parameterEfficiency * 100).toFixed(0);
+  const nextEventLabel =
+    eventCountdown <= 0 ? "Imminent" : `${eventCountdown}s`;
+
+  const omenMessage = useMemo(() => {
+    if (anomalies >= 4) {
+      return "Council warning: anomaly gardens are blooming; stabilise soon.";
+    }
+    if (resonance >= 18) {
+      return "The Cosmic Choir hums in harmony. Expect generous events.";
+    }
+    if (currentZone.requirement >= 10) {
+      return "Frontier scouts taste complexity in the air; brace for dazzling storms.";
+    }
+    return "Sensors idle with a gentle purr. Perfect time to chart expeditions.";
+  }, [anomalies, currentZone.requirement, resonance]);
 
   return (
     <Box className="startherebox">
@@ -313,8 +522,14 @@ export default function StartHere(): ReactElement {
         depth={depth}
         dataPerSecond={effectiveDataPerSecond}
         dimensionalPoints={dimensionalPoints}
+        resonance={resonance}
+        anomalies={anomalies}
       />
-      <Grid className="starthere-grid" columns={{ initial: "1", md: "2" }} gap="4">
+      <Grid
+        className="starthere-grid"
+        columns={{ initial: "1", md: "2" }}
+        gap="4"
+      >
         <Flex direction="column" gap="4">
           <Card className="fractal-card">
             <Flex justify="between" align="center" mb="3">
@@ -323,13 +538,18 @@ export default function StartHere(): ReactElement {
                 Zone bonus: +{Math.round((zoneBonus - 1) * 100)}%
               </Text>
             </Flex>
-            <FractalViewer depth={depth} parameter={complexParameter} amplifiers={amplifiers} />
+            <FractalViewer
+              depth={depth}
+              parameter={complexParameter}
+              amplifiers={amplifiers}
+            />
             <Separator my="3" size="4" />
             <Grid columns={{ initial: "1", sm: "2" }} gap="4">
               <Card className="control-card">
                 <Heading size="3">Manual Navigation</Heading>
                 <Text color="gray" size="2" mb="3">
-                  Each zoom consumes Fractal Data but reveals exponentially richer structures.
+                  Each zoom consumes Fractal Data but reveals exponentially
+                  richer structures.
                 </Text>
                 <Flex gap="3" mb="3" wrap="wrap">
                   <Button onClick={handleZoomDeeper} color="green">
@@ -340,32 +560,42 @@ export default function StartHere(): ReactElement {
                   </Button>
                 </Flex>
                 <Text size="2" color="gray">
-                  Passive stabilisers add {passiveDepthGain.toFixed(2)} depth / sec when active.
+                  Passive stabilisers add {passiveDepthGain.toFixed(2)} depth /
+                  sec when active.
                 </Text>
               </Card>
               <Card className="control-card">
                 <Heading size="3">Complex Parameter Tuning</Heading>
                 <Text size="2" color="gray">
-                  Align with the sweet spot (c = -0.75 + 0.11i) to maximise efficiency.
+                  Align with the sweet spot (c = -0.75 + 0.11i) to maximise
+                  efficiency.
                 </Text>
                 <Box className="slider-group">
-                  <Text weight="medium">Real: {complexParameter.real.toFixed(2)}</Text>
+                  <Text weight="medium">
+                    Real: {complexParameter.real.toFixed(2)}
+                  </Text>
                   <Slider
                     min={-2}
                     max={1}
                     step={0.01}
                     value={[complexParameter.real]}
-                    onValueChange={([value]) => handleParameterChange({ real: value })}
+                    onValueChange={([value]) =>
+                      handleParameterChange({ real: value })
+                    }
                   />
                 </Box>
                 <Box className="slider-group">
-                  <Text weight="medium">Imaginary: {complexParameter.imaginary.toFixed(2)}i</Text>
+                  <Text weight="medium">
+                    Imaginary: {complexParameter.imaginary.toFixed(2)}i
+                  </Text>
                   <Slider
                     min={-1}
                     max={1}
                     step={0.01}
                     value={[complexParameter.imaginary]}
-                    onValueChange={([value]) => handleParameterChange({ imaginary: value })}
+                    onValueChange={([value]) =>
+                      handleParameterChange({ imaginary: value })
+                    }
                   />
                 </Box>
                 <Text size="2" color="mint">
@@ -374,17 +604,91 @@ export default function StartHere(): ReactElement {
               </Card>
             </Grid>
           </Card>
+          <Card className="event-card">
+            <Heading size="4">Cosmic Forecast</Heading>
+            <Text size="2" color="gray">
+              The Galactic Cartographers share whimsical predictions about your
+              frontier.
+            </Text>
+            <Separator my="3" size="4" />
+            <Flex justify="between" align="center" mb="3">
+              <Flex direction="column">
+                <Text size="2" color="gray">
+                  Next phenomenon
+                </Text>
+                <Text size="3" weight="bold" color="mint">
+                  {nextEventLabel}
+                </Text>
+              </Flex>
+              <Badge
+                color={anomalies > 0 ? "iris" : "mint"}
+                variant="soft"
+                className="countdown-badge"
+              >
+                {omenMessage}
+              </Badge>
+            </Flex>
+            <Flex direction="column" gap="2" className="cosmic-stat">
+              <Flex justify="between" align="center">
+                <Text size="2">Resonance Flow</Text>
+                <Text size="2" color="mint">
+                  {resonance.toFixed(0)}
+                </Text>
+              </Flex>
+              <Box className="cosmic-meter">
+                <Box
+                  className="cosmic-meter-fill"
+                  style={{ width: `${Math.min(100, resonance * 5)}%` }}
+                />
+              </Box>
+            </Flex>
+            <Flex direction="column" gap="2" className="cosmic-stat">
+              <Flex justify="between" align="center">
+                <Text size="2">Anomaly Bloom</Text>
+                <Text size="2" color={anomalies > 0 ? "iris" : "gray"}>
+                  {anomalies}
+                </Text>
+              </Flex>
+              <Box className="cosmic-meter anomaly">
+                <Box
+                  className="cosmic-meter-fill"
+                  style={{ width: `${Math.min(100, anomalies * 20)}%` }}
+                />
+              </Box>
+            </Flex>
+            <Separator my="3" size="4" />
+            <Flex direction="column" gap="3">
+              <Button onClick={handleExpedition} color="cyan">
+                Dispatch Expedition (Cost: {formatNumber(expeditionCost)})
+              </Button>
+              <Text size="2" color="gray">
+                Expected haul: ~{expeditionPreview} resonance shards plus modest
+                depth insights.
+              </Text>
+              <Button
+                onClick={handleStabiliseAnomaly}
+                variant="soft"
+                color="purple"
+              >
+                Stabilise Anomaly (Cost: {formatNumber(stabiliseCost)})
+              </Button>
+            </Flex>
+          </Card>
           <Card className="zone-card">
             <Heading size="4">Exploration Zones</Heading>
             <Text size="2" color="gray">
-              Deeper zooms reveal new fractal biomes. Each grants a unique production bonus.
+              Deeper zooms reveal new fractal biomes. Each grants a unique
+              production bonus.
             </Text>
             <Separator my="3" size="4" />
             <Flex direction="column" gap="3">
               {FRACTAL_ZONES.map((zone) => {
                 const unlocked = depth >= zone.requirement;
                 return (
-                  <Card key={zone.name} className={`zone-entry ${unlocked ? "zone-unlocked" : "zone-locked"}`}>
+                  <Card
+                    key={zone.name}
+                    className={`zone-entry ${unlocked ? "zone-unlocked" : "zone-locked"}`}
+                  >
                     <Flex justify="between" align="center" mb="1">
                       <Heading size="3">{zone.name}</Heading>
                       <Text size="2" color={unlocked ? "mint" : "gray"}>
@@ -409,7 +713,8 @@ export default function StartHere(): ReactElement {
               Automation Upgrades
             </Heading>
             <Text size="2" color="gray">
-              Invest Fractal Data to automate exploration. Each stack compounds with your dimensional bonuses.
+              Invest Fractal Data to automate exploration. Each stack compounds
+              with your dimensional bonuses.
             </Text>
             <Separator my="3" size="4" />
             <Flex direction="column" gap="3">
@@ -444,7 +749,8 @@ export default function StartHere(): ReactElement {
               Dimensional Ascension
             </Heading>
             <Text size="2" color="gray">
-              Collapse the current fractal and start anew with permanent insight. Costs your progress but grants Dimensional Points.
+              Collapse the current fractal and start anew with permanent
+              insight. Costs your progress but grants Dimensional Points.
             </Text>
             <Separator my="3" size="4" />
             <Flex align="center" justify="between" mb="3">
@@ -454,18 +760,27 @@ export default function StartHere(): ReactElement {
                   Status: {ascendReady ? "Ready" : "Not yet"}
                 </Text>
               </Box>
-              <Button onClick={handleAscend} color={ascendReady ? "purple" : "gray"} variant={ascendReady ? "solid" : "soft"}>
+              <Button
+                onClick={handleAscend}
+                color={ascendReady ? "purple" : "gray"}
+                variant={ascendReady ? "solid" : "soft"}
+              >
                 Ascend
               </Button>
             </Flex>
             <Box className="prestige-upgrades">
               <Heading size="3">Dimensional Amplifiers</Heading>
               <Text size="2" color="gray">
-                Spend Dimensional Points for permanent production boosts that survive resets.
+                Spend Dimensional Points for permanent production boosts that
+                survive resets.
               </Text>
               <Flex align="center" justify="between" mt="2">
                 <Text size="2">Amplifiers owned: {amplifiers}</Text>
-                <Button onClick={handleAmplifierPurchase} variant="soft" color="mint">
+                <Button
+                  onClick={handleAmplifierPurchase}
+                  variant="soft"
+                  color="mint"
+                >
                   Buy ({amplifierCost} DP)
                 </Button>
               </Flex>
@@ -477,7 +792,11 @@ export default function StartHere(): ReactElement {
             </Heading>
             <Flex direction="column" gap="2">
               {activityLog.map((entry, index) => (
-                <Text key={`${entry}-${index}`} size="2" color={index === 0 ? "mint" : "gray"}>
+                <Text
+                  key={`${entry}-${index}`}
+                  size="2"
+                  color={index === 0 ? "mint" : "gray"}
+                >
                   {entry}
                 </Text>
               ))}

--- a/src/app/pages/starthere.tsx
+++ b/src/app/pages/starthere.tsx
@@ -299,28 +299,29 @@ export default function StartHere(): ReactElement {
 
   const triggerCosmicEvent = useCallback(() => {
     const { event, outcome } = resolveCosmicEvent(latestSnapshotRef.current);
-    if (outcome.dataDelta && outcome.dataDelta !== 0) {
-      setFractalData((previous) => Math.max(0, previous + outcome.dataDelta));
+    const {
+      dataDelta = 0,
+      resonanceDelta = 0,
+      anomaliesDelta = 0,
+      depthDelta = 0,
+      dimensionalPointsDelta = 0,
+    } = outcome;
+
+    if (dataDelta !== 0) {
+      setFractalData((previous) => Math.max(0, previous + dataDelta));
     }
-    if (outcome.resonanceDelta && outcome.resonanceDelta !== 0) {
-      setResonance((previous) =>
-        Math.max(0, previous + outcome.resonanceDelta),
-      );
+    if (resonanceDelta !== 0) {
+      setResonance((previous) => Math.max(0, previous + resonanceDelta));
     }
-    if (outcome.anomaliesDelta && outcome.anomaliesDelta !== 0) {
-      setAnomalies((previous) =>
-        Math.max(0, previous + outcome.anomaliesDelta),
-      );
+    if (anomaliesDelta !== 0) {
+      setAnomalies((previous) => Math.max(0, previous + anomaliesDelta));
     }
-    if (outcome.depthDelta && outcome.depthDelta !== 0) {
-      setDepth((previous) => Math.max(0, previous + outcome.depthDelta));
+    if (depthDelta !== 0) {
+      setDepth((previous) => Math.max(0, previous + depthDelta));
     }
-    if (
-      outcome.dimensionalPointsDelta &&
-      outcome.dimensionalPointsDelta !== 0
-    ) {
+    if (dimensionalPointsDelta !== 0) {
       setDimensionalPoints((previous) =>
-        Math.max(0, previous + outcome.dimensionalPointsDelta),
+        Math.max(0, previous + dimensionalPointsDelta),
       );
     }
     pushLog(`[Event] ${event.name}: ${outcome.log}`);
@@ -501,6 +502,7 @@ export default function StartHere(): ReactElement {
   const dimensionalEfficiency = (parameterEfficiency * 100).toFixed(0);
   const nextEventLabel =
     eventCountdown <= 0 ? "Imminent" : `${eventCountdown}s`;
+  const currentZoneRequirement = currentZone?.requirement ?? 0;
 
   const omenMessage = useMemo(() => {
     if (anomalies >= 4) {
@@ -509,11 +511,11 @@ export default function StartHere(): ReactElement {
     if (resonance >= 18) {
       return "The Cosmic Choir hums in harmony. Expect generous events.";
     }
-    if (currentZone.requirement >= 10) {
+    if (currentZoneRequirement >= 10) {
       return "Frontier scouts taste complexity in the air; brace for dazzling storms.";
     }
     return "Sensors idle with a gentle purr. Perfect time to chart expeditions.";
-  }, [anomalies, currentZone.requirement, resonance]);
+  }, [anomalies, currentZoneRequirement, resonance]);
 
   return (
     <Box className="startherebox">

--- a/src/app/pages/startheremenu.tsx
+++ b/src/app/pages/startheremenu.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import type { ReactElement } from "react";
 import React, { useEffect, useState } from "react";
@@ -10,6 +10,8 @@ type StartHereMenuProps = {
   depth: number;
   dataPerSecond: number;
   dimensionalPoints: number;
+  resonance: number;
+  anomalies: number;
 };
 
 const formatCompactNumber = (value: number): string => {
@@ -30,19 +32,26 @@ export default function StartHereMenu({
   depth,
   dataPerSecond,
   dimensionalPoints,
+  resonance,
+  anomalies,
 }: StartHereMenuProps): ReactElement {
   const [isDark, setIsDark] = useState<boolean>(true);
 
   useEffect(() => {
     try {
       document.documentElement.classList.toggle("dark", isDark);
-    } catch (e) {
+    } catch {
       /* noop */
     }
   }, [isDark]);
 
   return (
-    <Flex className="starthere-menu" align="center" justify="between" wrap="wrap">
+    <Flex
+      className="starthere-menu"
+      align="center"
+      justify="between"
+      wrap="wrap"
+    >
       <Flex align="center" gap="3">
         <Heading size="5" className="menu-title">
           Fractal Frontier Control Deck
@@ -50,23 +59,47 @@ export default function StartHereMenu({
         <button
           aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
           onClick={() => setIsDark((v) => !v)}
-          className="p-2 rounded-full bg-white/5 hover:bg-white/10"
+          className="rounded-full bg-white/5 p-2 hover:bg-white/10"
           title={isDark ? "Light mode" : "Dark mode"}
         >
           {isDark ? (
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <circle cx="12" cy="12" r="4" />
               <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
             </svg>
           ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
             </svg>
           )}
         </button>
       </Flex>
-      <Grid columns={{ initial: "1", sm: "2", md: "4" }} gap="3" width="auto">
-        <StatBadge label="Fractal Data" value={`${formatCompactNumber(fractalData)} units`} accent="mint" />
+      <Grid columns={{ initial: "1", sm: "2", md: "6" }} gap="3" width="auto">
+        <StatBadge
+          label="Fractal Data"
+          value={`${formatCompactNumber(fractalData)} units`}
+          accent="mint"
+        />
         <StatBadge
           label="Data / sec"
           value={`${formatCompactNumber(dataPerSecond)} /s`}
@@ -77,6 +110,16 @@ export default function StartHereMenu({
           label="Dimensional Points"
           value={dimensionalPoints.toFixed(0)}
           accent={dimensionalPoints > 0 ? "purple" : "gray"}
+        />
+        <StatBadge
+          label="Resonance"
+          value={resonance.toFixed(0)}
+          accent={resonance > anomalies ? "mint" : "iris"}
+        />
+        <StatBadge
+          label="Anomalies"
+          value={anomalies.toFixed(0)}
+          accent={anomalies > 0 ? "iris" : "gray"}
         />
       </Grid>
     </Flex>
@@ -92,7 +135,9 @@ type StatBadgeProps = {
 function StatBadge({ label, value, accent }: StatBadgeProps): ReactElement {
   return (
     <Flex direction="column" gap="1">
-      <Text size="1" color="gray">{label}</Text>
+      <Text size="1" color="gray">
+        {label}
+      </Text>
       <Badge color={accent} size="3">
         {value}
       </Badge>

--- a/src/styles/starthere.css
+++ b/src/styles/starthere.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
 .startherebox {
+  position: relative;
+  overflow: hidden;
   min-height: 100vh;
   padding: 2rem 1.5rem 3rem;
   background: radial-gradient(circle at top, rgba(64, 224, 208, 0.08), transparent 55%),
@@ -8,6 +10,30 @@
     radial-gradient(circle at bottom left, rgba(56, 189, 248, 0.06), transparent 40%),
     #050510;
   color: var(--gray-12);
+}
+
+.startherebox::before,
+.startherebox::after {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  pointer-events: none;
+  background: conic-gradient(
+    from 180deg,
+    rgba(45, 212, 191, 0.12),
+    rgba(99, 102, 241, 0.08),
+    rgba(45, 212, 191, 0.12)
+  );
+  filter: blur(40px);
+  opacity: 0.75;
+  animation: auroraFlow 24s linear infinite;
+}
+
+.startherebox::after {
+  animation-direction: reverse;
+  animation-duration: 36s;
+  mix-blend-mode: screen;
+  opacity: 0.4;
 }
 
 .starthere-grid {
@@ -39,7 +65,8 @@
 .log-card,
 .control-card,
 .zone-entry,
-.upgrade-row {
+.upgrade-row,
+.event-card {
   background: rgba(12, 12, 28, 0.85);
   border-radius: 18px;
   border: 1px solid rgba(120, 119, 198, 0.15);
@@ -57,7 +84,8 @@
 .zone-card,
 .upgrade-card,
 .prestige-card,
-.log-card {
+.log-card,
+.event-card {
   padding: 1.5rem;
 }
 
@@ -115,6 +143,59 @@
   height: 18px;
 }
 
+.event-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.event-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.18), transparent 55%);
+  opacity: 0.9;
+}
+
+.event-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.cosmic-stat {
+  padding: 0.5rem 0;
+}
+
+.cosmic-meter {
+  width: 100%;
+  height: 0.55rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.65);
+  overflow: hidden;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+}
+
+.cosmic-meter.anomaly {
+  border-color: rgba(139, 92, 246, 0.35);
+  background: rgba(30, 24, 75, 0.65);
+}
+
+.cosmic-meter-fill {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.8), rgba(16, 185, 129, 0.95));
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.cosmic-meter.anomaly .cosmic-meter-fill {
+  background: linear-gradient(90deg, rgba(165, 105, 255, 0.8), rgba(79, 70, 229, 0.95));
+}
+
+.countdown-badge {
+  white-space: normal;
+  text-align: right;
+  max-width: 220px;
+}
+
 .zone-entry {
   padding: 1.25rem;
   transition: transform 0.2s ease, border-color 0.2s ease;
@@ -164,6 +245,18 @@
   .prestige-card,
   .log-card {
     padding: 1.25rem;
+  }
+}
+
+@keyframes auroraFlow {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.05);
+  }
+  100% {
+    transform: rotate(360deg) scale(1);
   }
 }
 

--- a/tests/unit/cosmicEvents.test.ts
+++ b/tests/unit/cosmicEvents.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { COSMIC_EVENTS, resolveCosmicEvent } from "@/app/pages/cosmicEvents";
+
+const baseSnapshot = {
+  depth: 0,
+  resonance: 0,
+  anomalies: 0,
+  ascensionLevel: 0,
+  dimensionalPoints: 0,
+};
+
+describe("resolveCosmicEvent", () => {
+  it("selects the base event when the roll starts the weight range", () => {
+    const { event } = resolveCosmicEvent(baseSnapshot, () => 0);
+    expect(event.id).toBe(COSMIC_EVENTS[0]?.id);
+  });
+
+  it("selects eligible higher tier events when requirements are satisfied", () => {
+    const snapshot = {
+      depth: 7,
+      resonance: 8,
+      anomalies: 2,
+      ascensionLevel: 2,
+      dimensionalPoints: 5,
+    };
+    const { event } = resolveCosmicEvent(snapshot, () => 0.95);
+    expect((event.minDepth ?? -Infinity) <= snapshot.depth).toBe(true);
+    expect((event.minResonance ?? -Infinity) <= snapshot.resonance).toBe(true);
+  });
+
+  it("produces an outcome with descriptive log text", () => {
+    const snapshot = {
+      depth: 5,
+      resonance: 4,
+      anomalies: 1,
+      ascensionLevel: 1,
+      dimensionalPoints: 3,
+    };
+    const result = resolveCosmicEvent(snapshot, () => 0.4);
+    expect(result.outcome.log.length).toBeGreaterThan(0);
+    expect(result.event.name).toBeTypeOf("string");
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
  
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],
+    exclude: [...configDefaults.exclude, 'tests/e2e/**'],
   },
 })


### PR DESCRIPTION
## Summary
- add a cosmic event engine with resonance/anomaly resources and expedition actions to deepen gameplay
- refresh the StartHere menu and new Cosmic Forecast card with animated styling and live stats
- document the work in the memory bank, add targeted vitest coverage, and exclude Playwright specs from the unit test runner

## Testing
- npm run format:write
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68eb064a7e40832a9a5868a073c1468c