### PR TITLE
Add WebGL fractal renderer with CPU fallback toggle

### DIFF
--- a/memory/tasks/TASK010-implement-gpu-fractal-renderer.md
+++ b/memory/tasks/TASK010-implement-gpu-fractal-renderer.md
@@ -1,0 +1,51 @@
+# TASK010 - Implement GPU fractal renderer toggle
+
+**Status:** Completed
+**Added:** 2025-10-15
+**Updated:** 2025-10-15
+
+## Original Request
+
+Rewrite the fractal renderer as a GPU shader (preferably React Three Fiber / drei ShaderMaterial), keep the current CPU renderer as a fallback, and allow toggling between them. Update the "Fractal Frontier" label to indicate whether the WebGL or CPU renderer is active.
+
+## Thought Process
+
+- Moving to a GPU shader should eliminate canvas flickering and tearing by rendering frames atomically on the GPU.
+- Need to integrate React Three Fiber with the existing page without breaking current functionality.
+- Provide a toggle UI so users can switch between CPU and GPU implementations.
+- Update headings or labels dynamically to reflect the active renderer.
+- Ensure graceful fallback to the CPU renderer in environments without WebGL support or when the GPU renderer is disabled.
+- Keep the worker-based CPU renderer intact for comparison/testing until WebGL implementation is stable.
+
+## Implementation Plan
+
+- [x] Investigate existing fractal viewer component structure and data flow.
+- [x] Introduce a renderer mode state with options for CPU and WebGL.
+- [x] Implement a React Three Fiber scene with a ShaderMaterial computing the Mandelbrot set on the GPU.
+- [x] Render the GPU scene conditionally when WebGL mode is active; otherwise use the existing CPU canvas.
+- [x] Add UI controls (toggle/button) for switching between renderers and update the on-screen title accordingly.
+- [x] Ensure both renderers share configuration (viewport, parameters) where appropriate.
+- [x] Update styles/tests/types as necessary.
+- [x] Validate functionality manually and via automated checks.
+
+## Progress Tracking
+
+**Overall Status:** Completed - 100%
+
+### Subtasks
+
+| ID  | Description                                      | Status     | Updated    | Notes                                   |
+| --- | ------------------------------------------------ | ---------- | ---------- | --------------------------------------- |
+| 1.1 | Review current CPU fractal viewer implementation | Complete   | 2025-10-15 | Documented rendering flow and worker UX |
+| 1.2 | Design GPU shader approach and state toggle      | Complete   | 2025-10-15 | Planned shader uniforms and mode logic  |
+| 1.3 | Implement GPU renderer and integrate toggle      | Complete   | 2025-10-15 | Shader renderer built and validated      |
+| 1.4 | Update UI labels and finalize fallback behavior  | Complete   | 2025-10-15 | Toggle wired with heading updates        |
+| 1.5 | Run lint, type checks, and tests                 | Complete   | 2025-10-15 | Lint/typecheck/format/Vitest executed    |
+
+## Progress Log
+
+### 2025-10-15
+
+- Recorded task requirements and initial plan for GPU shader renderer toggle.
+- Implemented React Three Fiber shader-based renderer with CPU fallback toggle and dynamic heading label.
+- Ran Prettier, Next.js lint, TypeScript no-emit, and Vitest to validate the implementation.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -18,6 +18,7 @@
 
 - [TASK000] Project setup and Memory Bank creation - Completed on October 8, 2025
 - [TASK009] Enhance gameplay and visuals - Completed on October 10, 2025
+- [TASK010] Implement GPU fractal renderer toggle - Completed on October 15, 2025
 
 ## Abandoned
 

--- a/src/app/pages/fractalviewer.tsx
+++ b/src/app/pages/fractalviewer.tsx
@@ -1,25 +1,272 @@
-import { useEffect, useRef, useState } from "react";
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
+
+import { Button, Flex, Text } from "@radix-ui/themes";
+import { Canvas, extend, useFrame, useThree } from "@react-three/fiber";
+import type { ThreeElement } from "@react-three/fiber";
+import { shaderMaterial } from "@react-three/drei";
+import * as THREE from "three";
 
 type ComplexParameter = { real: number; imaginary: number };
 
-type FractalViewerProps = { depth: number; parameter: ComplexParameter; amplifiers: number };
+export type FractalRendererMode = "cpu" | "webgl";
+
+type FractalViewerProps = {
+  depth: number;
+  parameter: ComplexParameter;
+  amplifiers: number;
+  onRendererChange?: (mode: FractalRendererMode) => void;
+};
 
 const CANVAS_WIDTH = 360;
 const CANVAS_HEIGHT = 260;
 
-export default function FractalViewer({ depth, parameter, amplifiers }: FractalViewerProps): ReactElement {
+const FractalMaterial = shaderMaterial(
+  {
+    uResolution: new THREE.Vector2(1, 1),
+    uCenter: new THREE.Vector2(0, 0),
+    uZoom: 1,
+    uMaxIterations: 100,
+    uPaletteShift: 0,
+    uSaturation: 0.7,
+  },
+  /* gl_Position in clip space */
+  /* language=GLSL */ `
+    varying vec2 vUv;
+
+    void main() {
+      vUv = uv;
+      gl_Position = vec4(position, 1.0);
+    }
+  `,
+  /* language=GLSL */ `
+    precision highp float;
+
+    varying vec2 vUv;
+
+    uniform vec2 uResolution;
+    uniform vec2 uCenter;
+    uniform float uZoom;
+    uniform float uMaxIterations;
+    uniform float uPaletteShift;
+    uniform float uSaturation;
+
+    const int ITERATION_CAP = 1000;
+
+    vec3 hslToRgb(float h, float s, float l) {
+      float c = (1.0 - abs(2.0 * l - 1.0)) * s;
+      float hp = h * 6.0;
+      float x = c * (1.0 - abs(mod(hp, 2.0) - 1.0));
+      vec3 rgb = vec3(0.0);
+
+      if (hp < 1.0) rgb = vec3(c, x, 0.0);
+      else if (hp < 2.0) rgb = vec3(x, c, 0.0);
+      else if (hp < 3.0) rgb = vec3(0.0, c, x);
+      else if (hp < 4.0) rgb = vec3(0.0, x, c);
+      else if (hp < 5.0) rgb = vec3(x, 0.0, c);
+      else rgb = vec3(c, 0.0, x);
+
+      float m = l - 0.5 * c;
+      return rgb + vec3(m);
+    }
+
+    void main() {
+      // Convert UV to centered coordinates with aspect correction
+      vec2 uv = vUv * 2.0 - 1.0;
+      float aspect = uResolution.x / uResolution.y;
+      uv.x *= aspect;
+
+      vec2 c = vec2(
+        uCenter.x + uv.x / uZoom,
+        uCenter.y + uv.y / uZoom
+      );
+
+      vec2 z = vec2(0.0);
+      float maxIter = clamp(uMaxIterations, 1.0, float(ITERATION_CAP));
+      float iter = maxIter;
+
+      for (int i = 0; i < ITERATION_CAP; i++) {
+        if (float(i) >= maxIter) {
+          break;
+        }
+
+        float x = z.x * z.x - z.y * z.y + c.x;
+        float y = 2.0 * z.x * z.y + c.y;
+        z = vec2(x, y);
+
+        if (dot(z, z) > 4.0) {
+          iter = float(i);
+          break;
+        }
+      }
+
+      if (iter == maxIter) {
+        vec3 interior = hslToRgb(mod(uPaletteShift / 360.0, 1.0), uSaturation, 0.05);
+        gl_FragColor = vec4(interior, 1.0);
+        return;
+      }
+
+      float smoothIter = iter;
+      float zn = length(z);
+      if (zn > 0.0) {
+        smoothIter = iter + 1.0 - log(log(zn)) / log(2.0);
+      }
+      float normalised = smoothIter / maxIter;
+      float hue = mod((uPaletteShift + 360.0 * pow(normalised, 0.6)) / 360.0, 1.0);
+      float lightness = clamp(0.4 + normalised * 0.5, 0.1, 0.95);
+      vec3 color = hslToRgb(hue, clamp(uSaturation, 0.0, 1.0), lightness);
+      gl_FragColor = vec4(color, 1.0);
+    }
+  `,
+);
+extend({ FractalMaterial });
+
+type FractalMaterialUniforms = {
+  uResolution: { value: THREE.Vector2 };
+  uCenter: { value: THREE.Vector2 };
+  uZoom: { value: number };
+  uMaxIterations: { value: number };
+  uPaletteShift: { value: number };
+  uSaturation: { value: number };
+};
+
+type FractalMaterialInstance = InstanceType<typeof FractalMaterial> & {
+  uniforms: FractalMaterialUniforms;
+};
+
+declare module "@react-three/fiber" {
+  interface ThreeElements {
+    fractalMaterial: ThreeElement<typeof FractalMaterial>;
+  }
+}
+
+type FractalPlaneProps = {
+  depth: number;
+  parameter: ComplexParameter;
+  amplifiers: number;
+};
+
+function FractalPlane({ depth, parameter, amplifiers }: FractalPlaneProps) {
+  const materialRef = useRef<FractalMaterialInstance>(null);
+  const { size, gl } = useThree();
+
+  const parameters = useMemo(() => {
+    const maxIterations = Math.min(
+      1000,
+      Math.floor(40 + depth * 14 + amplifiers * 12),
+    );
+    const zoom = Math.pow(1.3, depth + amplifiers * 0.5);
+    const paletteShift = (((depth * 17 + amplifiers * 45) % 360) + 360) % 360;
+    const saturation = Math.min(
+      1,
+      Math.max(0, 0.7 + Math.sin(depth * 0.4) * 0.1),
+    );
+
+    return { maxIterations, zoom, paletteShift, saturation };
+  }, [amplifiers, depth]);
+
+  useEffect(() => {
+    const material = materialRef.current;
+    if (!material) return;
+
+    material.uniforms.uCenter.value.set(parameter.real, parameter.imaginary);
+  }, [parameter.imaginary, parameter.real]);
+
+  useEffect(() => {
+    const material = materialRef.current;
+    if (!material) return;
+
+    material.uniforms.uMaxIterations.value = parameters.maxIterations;
+    material.uniforms.uZoom.value = parameters.zoom;
+    material.uniforms.uPaletteShift.value = parameters.paletteShift;
+    material.uniforms.uSaturation.value = parameters.saturation;
+  }, [parameters]);
+
+  useFrame(() => {
+    const material = materialRef.current;
+    if (!material) return;
+
+    const dpr = gl.getPixelRatio();
+    material.uniforms.uResolution.value.set(
+      size.width * dpr,
+      size.height * dpr,
+    );
+  });
+
+  return (
+    <mesh>
+      <planeGeometry args={[2, 2]} />
+      <fractalMaterial ref={materialRef} />
+    </mesh>
+  );
+}
+
+function FractalWebGLSurface({
+  depth,
+  parameter,
+  amplifiers,
+}: FractalPlaneProps) {
+  return (
+    <Canvas
+      className="fractal-canvas"
+      orthographic
+      dpr={[1, 2]}
+      gl={{ antialias: false }}
+      camera={{ position: [0, 0, 1], zoom: 1 }}
+    >
+      <FractalPlane
+        depth={depth}
+        parameter={parameter}
+        amplifiers={amplifiers}
+      />
+    </Canvas>
+  );
+}
+
+export default function FractalViewer({
+  depth,
+  parameter,
+  amplifiers,
+  onRendererChange,
+}: FractalViewerProps): ReactElement {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const workerRef = useRef<Worker | null>(null);
   const resizeRef = useRef<ResizeObserver | null>(null);
-  const [size, setSize] = useState({ width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+  const [size, setSize] = useState({
+    width: CANVAS_WIDTH,
+    height: CANVAS_HEIGHT,
+  });
+  const [renderMode, setRenderMode] = useState<FractalRendererMode>("webgl");
+  const [webglSupported, setWebglSupported] = useState<boolean | null>(true);
+
+  const updateRendererMode = useCallback((mode: FractalRendererMode) => {
+    setRenderMode((prev) => {
+      if (prev === mode) return prev;
+      return mode;
+    });
+  }, []);
 
   useEffect(() => {
-    // Observe the container (pure-CSS alignment). The container width is
-    // governed by the card layout, separator and other content, so observing
-    // it ensures the canvas aligns visually with the separator and flex
-    // content above.
+    if (typeof window === "undefined") return;
+
+    const canvas = document.createElement("canvas");
+    const support = Boolean(
+      canvas.getContext("webgl2") ?? canvas.getContext("webgl"),
+    );
+    setWebglSupported(support);
+    if (!support) {
+      updateRendererMode("cpu");
+    }
+  }, [updateRendererMode]);
+
+  useEffect(() => {
+    onRendererChange?.(renderMode);
+  }, [onRendererChange, renderMode]);
+
+  useEffect(() => {
     const target = containerRef.current ?? canvasRef.current;
     if (!target || typeof window === "undefined") return;
 
@@ -30,7 +277,10 @@ export default function FractalViewer({ depth, parameter, amplifiers }: FractalV
         const entry = entries[0];
         if (!entry) return;
         const cr = entry.contentRect;
-        setSize({ width: Math.max(50, Math.floor(cr.width)), height: Math.max(50, Math.floor(cr.height)) });
+        setSize({
+          width: Math.max(50, Math.floor(cr.width)),
+          height: Math.max(50, Math.floor(cr.height)),
+        });
       });
       resizeRef.current = ro;
       ro.observe(target as Element);
@@ -41,10 +291,12 @@ export default function FractalViewer({ depth, parameter, amplifiers }: FractalV
       };
     }
 
-    // Fallback: measure via getBoundingClientRect and listen for window resize
     const updateSize = () => {
       const rect = (target as Element).getBoundingClientRect();
-      setSize({ width: Math.max(50, Math.floor(rect.width)), height: Math.max(50, Math.floor(rect.height)) });
+      setSize({
+        width: Math.max(50, Math.floor(rect.width)),
+        height: Math.max(50, Math.floor(rect.height)),
+      });
     };
     updateSize();
     window.addEventListener("resize", updateSize);
@@ -54,30 +306,37 @@ export default function FractalViewer({ depth, parameter, amplifiers }: FractalV
   }, []);
 
   useEffect(() => {
+    if (renderMode !== "cpu") {
+      if (workerRef.current) {
+        workerRef.current.terminate();
+        workerRef.current = null;
+      }
+      return;
+    }
+
     const canvas = canvasRef.current;
     if (!canvas || typeof window === "undefined") return;
-    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    const dpr = Math.max(1, window.devicePixelRatio ?? 1);
 
-    // compute pixel size based on CSS size and DPR
     const pixelWidth = Math.max(1, Math.floor(size.width * dpr));
     const pixelHeight = Math.max(1, Math.floor(size.height * dpr));
 
-    // set canvas pixel dimensions and CSS size
-    canvas.width = pixelWidth;
-    canvas.height = pixelHeight;
+    if (canvas.width !== pixelWidth) {
+      canvas.width = pixelWidth;
+    }
+    if (canvas.height !== pixelHeight) {
+      canvas.height = pixelHeight;
+    }
     canvas.style.width = `${size.width}px`;
     canvas.style.height = `${size.height}px`;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // terminate previous worker if any
     if (workerRef.current) {
       workerRef.current.terminate();
       workerRef.current = null;
     }
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     const workerCode = `
       self.onmessage = function(e) {
@@ -129,52 +388,124 @@ export default function FractalViewer({ depth, parameter, amplifiers }: FractalV
       };
     `;
 
-    const blob = new Blob([workerCode], { type: 'application/javascript' });
-    const worker = new Worker(URL.createObjectURL(blob));
+    const blob = new Blob([workerCode], { type: "application/javascript" });
+    const objectUrl = URL.createObjectURL(blob);
+    const worker = new Worker(objectUrl);
     workerRef.current = worker;
 
     const tileHeight = Math.max(4, Math.floor(8 * dpr));
+    const pendingTiles: Array<{ y: number; data: ImageData }> = [];
+    let scheduled = false;
 
-    worker.onmessage = (ev: MessageEvent) => {
-      const msg = ev.data as
-        | { type: 'tile'; y: number; height: number; width: number; buffer: ArrayBuffer }
-        | { type: 'done' };
-      if (msg.type === 'tile') {
-        const { y, height: h, width, buffer } = msg;
-        requestAnimationFrame(() => {
-          try {
-            const uint = new Uint8ClampedArray(buffer);
-            const imageData = new ImageData(uint, width, h);
-            // draw using pixel coordinates (worker produced DPR-scaled pixels)
-            ctx.putImageData(imageData, 0, y);
-          } catch {
-            // ignore
-          }
-        });
+    const flushTiles = () => {
+      if (!ctx) return;
+      scheduled = false;
+      for (const tile of pendingTiles.splice(0, pendingTiles.length)) {
+        ctx.putImageData(tile.data, 0, tile.y);
       }
     };
 
-    // start rendering with pixel dimensions
-    worker.postMessage({ width: pixelWidth, height: pixelHeight, depth, parameter, amplifiers, tileHeight });
+    worker.onmessage = (ev) => {
+      const msg = ev.data as
+        | {
+            type: "tile";
+            y: number;
+            height: number;
+            width: number;
+            buffer: ArrayBuffer;
+          }
+        | { type: "done" };
+      if (msg.type === "tile") {
+        const { y, height: h, width, buffer } = msg;
+        const uint = new Uint8ClampedArray(buffer);
+        const imageData = new ImageData(uint, width, h);
+        pendingTiles.push({ y, data: imageData });
+        if (!scheduled) {
+          scheduled = true;
+          requestAnimationFrame(flushTiles);
+        }
+      }
+    };
+
+    worker.postMessage({
+      width: pixelWidth,
+      height: pixelHeight,
+      depth,
+      parameter,
+      amplifiers,
+      tileHeight,
+    });
 
     return () => {
       if (workerRef.current) {
         workerRef.current.terminate();
         workerRef.current = null;
       }
+      URL.revokeObjectURL(objectUrl);
     };
-  }, [depth, parameter, amplifiers, size]);
+  }, [amplifiers, depth, parameter, renderMode, size.height, size.width]);
+
+  const handleCpuClick = useCallback(
+    () => updateRendererMode("cpu"),
+    [updateRendererMode],
+  );
+  const handleWebglClick = useCallback(
+    () => updateRendererMode("webgl"),
+    [updateRendererMode],
+  );
 
   return (
-    <div ref={containerRef} className="fractal-canvas-wrap">
-      <canvas
-        ref={canvasRef}
-        width={CANVAS_WIDTH}
-        height={CANVAS_HEIGHT}
-        className="fractal-canvas"
-        aria-label="Fractal renderer showing the current zoom level"
-      />
+    <div className="fractal-viewer">
+      <Flex
+        className="fractal-renderer-controls"
+        justify="between"
+        align="center"
+      >
+        <Text size="2" color="gray">
+          Renderer Mode
+        </Text>
+        <Flex gap="2" className="fractal-renderer-toggle-group">
+          <Button
+            size="1"
+            variant={renderMode === "webgl" ? "solid" : "soft"}
+            color={renderMode === "webgl" ? "mint" : "gray"}
+            onClick={handleWebglClick}
+            disabled={webglSupported === false}
+          >
+            WebGL
+          </Button>
+          <Button
+            size="1"
+            variant={renderMode === "cpu" ? "solid" : "soft"}
+            color={renderMode === "cpu" ? "mint" : "gray"}
+            onClick={handleCpuClick}
+          >
+            CPU
+          </Button>
+        </Flex>
+      </Flex>
+      {webglSupported === false && (
+        <Text size="2" color="tomato" className="fractal-renderer-warning">
+          WebGL is not available; falling back to the CPU renderer.
+        </Text>
+      )}
+      <div ref={containerRef} className="fractal-canvas-wrap">
+        {renderMode === "webgl" && webglSupported !== false ? (
+          <FractalWebGLSurface
+            depth={depth}
+            parameter={parameter}
+            amplifiers={amplifiers}
+          />
+        ) : (
+          <canvas
+            ref={canvasRef}
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            className="fractal-canvas"
+            aria-label="Fractal renderer showing the current zoom level"
+          />
+        )}
+      </div>
     </div>
   );
 }
-

--- a/src/app/pages/starthere.tsx
+++ b/src/app/pages/starthere.tsx
@@ -18,7 +18,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 
-import FractalViewer from "./fractalviewer";
+import FractalViewer, { type FractalRendererMode } from "./fractalviewer";
 import StartHereMenu from "./startheremenu";
 import { resolveCosmicEvent } from "./cosmicEvents";
 
@@ -517,6 +517,9 @@ export default function StartHere(): ReactElement {
     return "Sensors idle with a gentle purr. Perfect time to chart expeditions.";
   }, [anomalies, currentZoneRequirement, resonance]);
 
+  const [rendererMode, setRendererMode] =
+    useState<FractalRendererMode>("webgl");
+
   return (
     <Box className="startherebox">
       <StartHereMenu
@@ -535,7 +538,9 @@ export default function StartHere(): ReactElement {
         <Flex direction="column" gap="4">
           <Card className="fractal-card">
             <Flex justify="between" align="center" mb="3">
-              <Heading size="4">Fractal Frontier</Heading>
+              <Heading size="4">
+                Fractal Frontier {rendererMode === "webgl" ? "WebGL" : "CPU"}
+              </Heading>
               <Text size="2" color="mint">
                 Zone bonus: +{Math.round((zoneBonus - 1) * 100)}%
               </Text>
@@ -544,6 +549,7 @@ export default function StartHere(): ReactElement {
               depth={depth}
               parameter={complexParameter}
               amplifiers={amplifiers}
+              onRendererChange={setRendererMode}
             />
             <Separator my="3" size="4" />
             <Grid columns={{ initial: "1", sm: "2" }} gap="4">

--- a/src/styles/starthere.css
+++ b/src/styles/starthere.css
@@ -113,6 +113,26 @@
   box-sizing: border-box; /* ensure width measurement includes padding/border consistently */
 }
 
+.fractal-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.fractal-renderer-controls {
+  width: 100%;
+}
+
+.fractal-renderer-toggle-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.fractal-renderer-warning {
+  margin-top: -0.25rem;
+  margin-bottom: 0.25rem;
+}
+
 @media (min-width: 1024px) {
   /* on large screens keep the original aspect ratio but allow a larger min size */
   .fractal-canvas {


### PR DESCRIPTION
## Summary
- introduce a React Three Fiber shader-based WebGL fractal renderer alongside the existing CPU worker implementation with runtime toggling
- surface the active renderer mode in the Start Here heading and add styling for the new renderer controls
- record the GPU renderer task in the memory bank and update the task index

## Testing
- npm run format:write
- npm run lint
- npm run typecheck
- npm run test
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68eb76c543f4832a8a6b4925ff431112