### PR TITLE
Refactor duplicate logic in gameData and gameStore

### DIFF
--- a/src/app/components/Game.tsx
+++ b/src/app/components/Game.tsx
@@ -24,7 +24,7 @@ export default function Game() {
   const axiom = useGameStore((state) => state.axiom);
   const activeRules = useGameStore((state) => state.activeRules);
   const analysisMode = useGameStore((state) => state.analysisMode);
-  const unlocks = useGameStore((state) => state.unlocks);
+  const purchasedSeedUpgrades = useGameStore((state) => state.purchasedSeedUpgrades);
   const fruit = useGameStore((state) => state.fruit);
   const geometry = useGameStore((state) => state.selectedGeometry);
 
@@ -40,8 +40,8 @@ export default function Game() {
     angle,
     step,
     width,
-    enablePitch: unlocks.pitch,
-    enableRoll: unlocks.roll,
+    enablePitch: purchasedSeedUpgrades.includes("pitch"),
+    enableRoll: purchasedSeedUpgrades.includes("roll"),
   });
 
   const rates = useMemo(() => {

--- a/src/app/components/panels/ControlPanel.tsx
+++ b/src/app/components/panels/ControlPanel.tsx
@@ -11,7 +11,7 @@ export type ControlPanelProps = {
 export default function ControlPanel({ suggestedAngle }: ControlPanelProps) {
   const angle = useGameStore((state) => state.angle);
   const analysisMode = useGameStore((state) => state.analysisMode);
-  const autoTuner = useGameStore((state) => state.unlocks.autoTuner);
+  const autoTuner = useGameStore((state) => state.purchasedSeedUpgrades.includes("autoTuner"));
   const setAngle = useGameStore((state) => state.setAngle);
   const toggleAnalysis = useGameStore((state) => state.toggleAnalysis);
 

--- a/src/app/components/panels/SeedShopPanel.tsx
+++ b/src/app/components/panels/SeedShopPanel.tsx
@@ -7,21 +7,12 @@ import { formatNumber } from "@/lib/format";
 
 export default function SeedShopPanel() {
   const seeds = useGameStore((state) => state.seeds);
-  const unlocks = useGameStore((state) => state.unlocks);
-  const geometryUnlocks = useGameStore((state) => state.geometryUnlocks);
+  const purchasedSeedUpgrades = useGameStore((state) => state.purchasedSeedUpgrades);
   const selectedGeometry = useGameStore((state) => state.selectedGeometry);
   const buySeedUpgrade = useGameStore((state) => state.buySeedUpgrade);
   const selectGeometry = useGameStore((state) => state.selectGeometry);
 
-  const isUpgradePurchased = (id: string) => {
-    if (id === "pitch") return unlocks.pitch;
-    if (id === "roll") return unlocks.roll;
-    if (id === "autoTuner") return unlocks.autoTuner;
-    if (id === "geometry_cone") return geometryUnlocks.cone;
-    if (id === "geometry_box") return geometryUnlocks.box;
-    if (id === "geometry_tetra") return geometryUnlocks.tetra;
-    return false;
-  };
+
 
   return (
     <CollapsiblePanel
@@ -32,7 +23,7 @@ export default function SeedShopPanel() {
     >
       <div className="seed-grid">
         {SEED_UPGRADES.map((upgrade) => {
-          const owned = isUpgradePurchased(upgrade.id);
+          const owned = purchasedSeedUpgrades.includes(upgrade.id);
           const canAfford = seeds >= upgrade.cost;
           return (
             <div key={upgrade.id} className={`seed-card ${owned ? "seed-card--owned" : ""}`}>
@@ -53,7 +44,7 @@ export default function SeedShopPanel() {
       <div className="panel__subtitle">Branch Geometry</div>
       <div className="geometry-grid">
         {GEOMETRY_OPTIONS.map((option) => {
-          const unlocked = geometryUnlocks[option.id];
+          const unlocked = option.id === "cylinder" || purchasedSeedUpgrades.includes(`geometry_${option.id}`);
           const selected = selectedGeometry === option.id;
           return (
             <button

--- a/src/app/components/panels/genome/RuleCard.tsx
+++ b/src/app/components/panels/genome/RuleCard.tsx
@@ -15,7 +15,7 @@ export function RuleCard({ rule, symbol }: RuleCardProps) {
   const seeds = useGameStore((state) => state.seeds);
   const unlockedRules = useGameStore((state) => state.unlockedRules);
   const activeRules = useGameStore((state) => state.activeRules);
-  const unlocks = useGameStore((state) => state.unlocks);
+  const purchasedSeedUpgrades = useGameStore((state) => state.purchasedSeedUpgrades);
   const unlockRule = useGameStore((state) => state.unlockRule);
   const setActiveRule = useGameStore((state) => state.setActiveRule);
 
@@ -24,7 +24,7 @@ export function RuleCard({ rule, symbol }: RuleCardProps) {
   const requiresPitch = rule.requires?.pitch ?? false;
   const requiresRoll = rule.requires?.roll ?? false;
   const lockReason =
-    (requiresPitch && !unlocks.pitch) || (requiresRoll && !unlocks.roll);
+    (requiresPitch && !purchasedSeedUpgrades.includes("pitch")) || (requiresRoll && !purchasedSeedUpgrades.includes("roll"));
 
   const costLabel = rule.cost.photosynthesis
     ? `P ${formatNumber(rule.cost.photosynthesis)}`

--- a/src/app/hooks/useGameLoop.ts
+++ b/src/app/hooks/useGameLoop.ts
@@ -5,7 +5,7 @@ export type GameLoopRates = ResourceRates & { suggestedAngle: number };
 
 export function useGameLoop(rates: GameLoopRates) {
   const addResources = useGameStore((state) => state.addResources);
-  const autoTuner = useGameStore((state) => state.unlocks.autoTuner);
+  const autoTuner = useGameStore((state) => state.purchasedSeedUpgrades.includes("autoTuner"));
   const angle = useGameStore((state) => state.angle);
   const setAngle = useGameStore((state) => state.setAngle);
 

--- a/src/lib/gameData.ts
+++ b/src/lib/gameData.ts
@@ -245,24 +245,25 @@ export function getTickMultiplier(level: number): number {
   return 1 + level * 0.15;
 }
 
+export function calculateCost(base: number, multiplier: number, level: number, season: SeasonId): number {
+  const costBase = base * Math.pow(multiplier, level);
+  return Math.round(costBase * SEASONS[season].costMultiplier);
+}
+
 export function getIterationCost(iterations: number, season: SeasonId): number {
-  const base = 24 * Math.pow(1.85, iterations);
-  return Math.round(base * SEASONS[season].costMultiplier);
+  return calculateCost(24, 1.85, iterations, season);
 }
 
 export function getWidthCost(level: number, season: SeasonId): number {
-  const base = 20 * Math.pow(1.55, level + 1);
-  return Math.round(base * SEASONS[season].costMultiplier);
+  return calculateCost(20, 1.55, level + 1, season);
 }
 
 export function getTickCost(level: number, season: SeasonId): number {
-  const base = 26 * Math.pow(1.7, level + 1);
-  return Math.round(base * SEASONS[season].costMultiplier);
+  return calculateCost(26, 1.7, level + 1, season);
 }
 
 export function getFruitCost(fruit: number, season: SeasonId): number {
-  const base = 35 * Math.pow(1.35, fruit + 1);
-  return Math.round(base * SEASONS[season].costMultiplier);
+  return calculateCost(35, 1.35, fruit + 1, season);
 }
 
 export function getAxiomCost(nextAxiom: string): number {

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -37,11 +37,11 @@ export type GameState = {
   activeRules: Record<string, string>;
   unlockedRules: string[];
   analysisMode: boolean;
-  geometryUnlocks: Record<GeometryType, boolean>;
   selectedGeometry: GeometryType;
-  unlocks: { pitch: boolean; roll: boolean; autoTuner: boolean };
+  purchasedSeedUpgrades: string[];
   lastMutation: number;
   lastRuleChanged: string | null;
+  _performUpgrade: (cost: number, currency: "photosynthesis" | "sap" | "seeds", updater: Partial<GameState>) => boolean;
   addResources: (dt: number, rates: ResourceRates) => void;
   setAngle: (angle: number) => void;
   toggleAnalysis: () => void;
@@ -56,13 +56,6 @@ export type GameState = {
   selectGeometry: (geometry: GeometryType) => void;
   buySeedUpgrade: (upgradeId: string) => void;
   harvest: () => void;
-};
-
-const defaultGeometryUnlocks: Record<GeometryType, boolean> = {
-  cylinder: true,
-  cone: false,
-  box: false,
-  tetra: false,
 };
 
 export const useGameStore = create<GameState>((set, get) => ({
@@ -81,11 +74,16 @@ export const useGameStore = create<GameState>((set, get) => ({
   activeRules: { X: "sprout", F: "stem" },
   unlockedRules: ["sprout", "stem"],
   analysisMode: false,
-  geometryUnlocks: defaultGeometryUnlocks,
   selectedGeometry: "cylinder",
-  unlocks: { pitch: false, roll: false, autoTuner: false },
+  purchasedSeedUpgrades: [],
   lastMutation: Date.now(),
   lastRuleChanged: null,
+  _performUpgrade: (cost: number, currency: "photosynthesis" | "sap" | "seeds", updater: Partial<GameState>) => {
+    const state = get();
+    if (state[currency] < cost) return false;
+    set({ [currency]: state[currency] - cost, ...updater, lastMutation: Date.now() });
+    return true;
+  },
   addResources: (dt, rates) => {
     if (dt <= 0) return;
     set((state) => ({
@@ -107,39 +105,31 @@ export const useGameStore = create<GameState>((set, get) => ({
     const state = get();
     if (state.iterations >= MAX_ITERATIONS) return;
     const cost = getIterationCost(state.iterations, state.season);
-    if (state.photosynthesis < cost) return;
-    set({
-      photosynthesis: state.photosynthesis - cost,
-      iterations: state.iterations + 1,
-      lastMutation: Date.now(),
-    });
+    get()._performUpgrade(cost, "photosynthesis", { iterations: state.iterations + 1 });
   },
   buyWidth: () => {
     const state = get();
     const cost = getWidthCost(state.widthLevel, state.season);
-    if (state.sap < cost) return;
-    set({ sap: state.sap - cost, widthLevel: state.widthLevel + 1, lastMutation: Date.now() });
+    get()._performUpgrade(cost, "sap", { widthLevel: state.widthLevel + 1 });
   },
   buyTickRate: () => {
     const state = get();
     const cost = getTickCost(state.tickLevel, state.season);
-    if (state.sap < cost) return;
-    set({ sap: state.sap - cost, tickLevel: state.tickLevel + 1, lastMutation: Date.now() });
+    get()._performUpgrade(cost, "sap", { tickLevel: state.tickLevel + 1 });
   },
   buyFruit: () => {
     const state = get();
     if (state.season !== "autumn") return;
     const cost = getFruitCost(state.fruit, state.season);
-    if (state.sap < cost) return;
-    set({ sap: state.sap - cost, fruit: state.fruit + 1, lastMutation: Date.now() });
+    get()._performUpgrade(cost, "sap", { fruit: state.fruit + 1 });
   },
   unlockRule: (ruleId) => {
     const state = get();
     if (state.unlockedRules.includes(ruleId)) return;
     const rule = RULE_LIBRARY.find((entry) => entry.id === ruleId);
     if (!rule) return;
-    if (rule.requires?.pitch && !state.unlocks.pitch) return;
-    if (rule.requires?.roll && !state.unlocks.roll) return;
+    if (rule.requires?.pitch && !state.purchasedSeedUpgrades.includes("pitch")) return;
+    if (rule.requires?.roll && !state.purchasedSeedUpgrades.includes("roll")) return;
     const photoCost = rule.cost.photosynthesis ?? 0;
     const sapCost = rule.cost.sap ?? 0;
     const seedCost = rule.cost.seeds ?? 0;
@@ -183,30 +173,15 @@ export const useGameStore = create<GameState>((set, get) => ({
   },
   selectGeometry: (geometry) => {
     const state = get();
-    if (!state.geometryUnlocks[geometry]) return;
+    if (geometry !== "cylinder" && !state.purchasedSeedUpgrades.includes(`geometry_${geometry}`)) return;
     set({ selectedGeometry: geometry });
   },
   buySeedUpgrade: (upgradeId) => {
     const state = get();
+    if (state.purchasedSeedUpgrades.includes(upgradeId)) return;
     const upgrade = SEED_UPGRADES.find((entry) => entry.id === upgradeId);
     if (!upgrade) return;
-    if (state.seeds < upgrade.cost) return;
-
-    const nextUnlocks = { ...state.unlocks };
-    const nextGeometry = { ...state.geometryUnlocks };
-
-    if (upgradeId === "pitch") nextUnlocks.pitch = true;
-    if (upgradeId === "roll") nextUnlocks.roll = true;
-    if (upgradeId === "autoTuner") nextUnlocks.autoTuner = true;
-    if (upgradeId === "geometry_cone") nextGeometry.cone = true;
-    if (upgradeId === "geometry_box") nextGeometry.box = true;
-    if (upgradeId === "geometry_tetra") nextGeometry.tetra = true;
-
-    set({
-      seeds: state.seeds - upgrade.cost,
-      unlocks: nextUnlocks,
-      geometryUnlocks: nextGeometry,
-    });
+    get()._performUpgrade(upgrade.cost, "seeds", { purchasedSeedUpgrades: [...state.purchasedSeedUpgrades, upgradeId] });
   },
   harvest: () => {
     const state = get();


### PR DESCRIPTION
- Created a unified `calculateCost` helper in `src/lib/gameData.ts`.
- Introduced a shared `_performUpgrade` helper in `src/store/gameStore.ts`.
- Consolidated upgrade tracking by replacing `unlocks` and `geometryUnlocks` with a single `purchasedSeedUpgrades` array.
- Updated all consuming components and hooks to use the new array.

---
*PR created automatically by Jules for task [17828445119071907344](https://jules.google.com/task/17828445119071907344) started by @deadronos*